### PR TITLE
Add schedulers and refactor subscriptions

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build_and_generate_report:

--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -35,8 +35,8 @@ jobs:
 
     - name: Configure CMake
       env:
-        CC: clang
-        CXX: clang++
+        CC: gcc-10
+        CXX: g++-10
       run: cmake -B ${{github.workspace}}/build -DAUTOTESTS=1 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCODE_COVERAGE=1
         
     - name: Build

--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -35,8 +35,8 @@ jobs:
 
     - name: Configure CMake
       env:
-        CC: gcc-10
-        CXX: g++-10
+        CC: clang
+        CXX: clang++
       run: cmake -B ${{github.workspace}}/build -DAUTOTESTS=1 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCODE_COVERAGE=1
         
     - name: Build

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,7 +24,7 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        git diff -U0 origin/main | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml -extra-arg=-std=c++20 -clang-tidy-binary "clang-tidy -header-filter=.*"
+        git diff -U0 origin/main | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml -extra-arg=-std=c++20
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@master
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,6 @@ if(CODE_COVERAGE)
     --coverage # sets all required flags
     -fprofile-arcs 
     -ftest-coverage
-    -fprofile-instr-generate 
-    -fcoverage-mapping
   )
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
     target_link_options(coverage_config INTERFACE --coverage)
@@ -86,7 +84,11 @@ endif()
 enable_testing()
 
 macro (add_ctest target)
-  add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}> -r junit -o ${TEST_RESULTS_DIR}/${target}.xml ~[benchmark] ~[misc_benchmark])
+  if(CODE_COVERAGE)
+    add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}> ~[benchmark] ~[misc_benchmark])
+  else()
+    add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}> -r junit -o ${TEST_RESULTS_DIR}/${target}.xml ~[benchmark] ~[misc_benchmark])
+  endif()
 endmacro (add_ctest)
 
 file(MAKE_DIRECTORY ${TEST_RESULTS_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 # ======================= CI =========================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # 
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(ReactivePlusPlus VERSION 0.1 LANGUAGES C CXX)
 
@@ -36,6 +36,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+# ======================= CI =========================
 set(TEST_RESULTS_DIR  ${CMAKE_BINARY_DIR}/test_results)
 set(BUILD_TESTS ON CACHE BOOL "Enable unit tests building" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # 
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.12)
 
 project(ReactivePlusPlus VERSION 0.1 LANGUAGES C CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ if(CODE_COVERAGE)
     --coverage # sets all required flags
     -fprofile-arcs 
     -ftest-coverage
+    -fprofile-instr-generate 
+    -fcoverage-mapping
   )
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
     target_link_options(coverage_config INTERFACE --coverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # 
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.19)
 
 project(ReactivePlusPlus VERSION 0.1 LANGUAGES C CXX)
 

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -26,7 +26,7 @@ file(GLOB_RECURSE FILES "*.h")
 add_library(rpp INTERFACE ${FILES})
 target_sources(rpp INTERFACE ${FILES})
 target_include_directories(rpp INTERFACE .)
-target_link_libraries(rpp INTERFACE coverage_config)
+target_link_libraries(rpp INTERFACE coverage_config Threads::Threads)
 
 foreach(FILE ${FILES}) 
   get_filename_component(PARENT_DIR "${FILE}" PATH)

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -23,7 +23,12 @@
 
 file(GLOB_RECURSE FILES "*.h")
 
-add_library(rpp INTERFACE ${FILES})
+if(${CMAKE_VERSION} VERSION_LESS "3.19.0")
+  add_library(rpp INTERFACE)
+else()
+  add_library(rpp INTERFACE ${FILES})
+endif()
+
 target_sources(rpp INTERFACE ${FILES})
 target_include_directories(rpp INTERFACE .)
 target_link_libraries(rpp INTERFACE coverage_config Threads::Threads)

--- a/src/include/rpp/observables/dynamic_observable.h
+++ b/src/include/rpp/observables/dynamic_observable.h
@@ -53,14 +53,14 @@ public:
     dynamic_observable(const dynamic_observable<Type>&)     = default;
     dynamic_observable(dynamic_observable<Type>&&) noexcept = default;
 
-    subscription subscribe(const dynamic_subscriber<Type>& subscriber) const noexcept override
+    composite_subscription subscribe(const dynamic_subscriber<Type>& subscriber) const noexcept override
     {
         return m_observable->subscribe(subscriber);
     }
 
     template<typename ...Args>
         requires (std::is_constructible_v<dynamic_subscriber<Type>, Args...> && !constraint::variadic_is_same_type<dynamic_subscriber<Type>, Args...>)
-    subscription subscribe(Args&&...args) const noexcept
+    composite_subscription subscribe(Args&&...args) const noexcept
     {
         return m_observable->subscribe(dynamic_subscriber<Type>{std::forward<Args>(args)...});
     }

--- a/src/include/rpp/observables/interface_observable.h
+++ b/src/include/rpp/observables/interface_observable.h
@@ -93,7 +93,7 @@ struct virtual_observable : public details::observable_tag
      * \brief Main function of observable. Initiates subscription for provided subscriber and calls stored OnSubscribe function
      * \return subscription on this observable which can be used to unsubscribe
      */
-    virtual subscription subscribe(const dynamic_subscriber<Type>& subscriber) const noexcept = 0;
+    virtual composite_subscription subscribe(const dynamic_subscriber<Type>& subscriber) const noexcept = 0;
 };
 
 /**

--- a/src/include/rpp/operators/map.h
+++ b/src/include/rpp/operators/map.h
@@ -29,6 +29,7 @@
  */
 
 #include <rpp/observables/constraints.h>
+#include <rpp/subscribers/constraints.h>
 #include <rpp/observables/type_traits.h>
 
 #include <utility>

--- a/src/include/rpp/schedulers/constraints.h
+++ b/src/include/rpp/schedulers/constraints.h
@@ -30,5 +30,5 @@ namespace rpp::schedulers::constraint
 {
 // returns nullopt in case of don't need to reshedule scheulable or some duration which will be added to "now" and resheduled
 template<typename T>
-concept schedulable_fn = std::is_invocable_r_v<std::optional<duration>, T>;
+concept schedulable_fn = std::is_invocable_r_v<optional_duration, T>;
 } // namespace rpp::schedulers::constraint

--- a/src/include/rpp/schedulers/constraints.h
+++ b/src/include/rpp/schedulers/constraints.h
@@ -22,4 +22,13 @@
 
 #pragma once
 
-#include <rpp/operators/map.h>
+#include <rpp/schedulers/fwd.h>
+
+#include <concepts>
+
+namespace rpp::schedulers::constraint
+{
+// returns nullopt in case of don't need to reshedule scheulable or some duration which will be added to "now" and resheduled
+template<typename T>
+concept schedulable_fn = std::is_invocable_r_v<std::optional<duration>, T>;
+} // namespace rpp::schedulers::constraint

--- a/src/include/rpp/schedulers/fwd.h
+++ b/src/include/rpp/schedulers/fwd.h
@@ -22,4 +22,18 @@
 
 #pragma once
 
-#include <rpp/operators/map.h>
+#include <chrono>
+#include <optional>
+
+namespace rpp::schedulers::details
+{
+struct scheduler_tag {};
+} // namespace rpp::schedulers::details
+
+namespace rpp::schedulers
+{
+using clock_type = std::chrono::high_resolution_clock;
+using time_point = std::chrono::high_resolution_clock::time_point;
+using duration   = std::chrono::nanoseconds;
+using optional_duration = std::optional<duration>;
+} // namespace rpp::schedulers

--- a/src/include/rpp/schedulers/immediate_scheduler.h
+++ b/src/include/rpp/schedulers/immediate_scheduler.h
@@ -53,10 +53,10 @@ public:
             while (m_sub.is_subscribed())
             {
                 std::this_thread::sleep_until(time_point);
-                auto duration = fn();
-                if (!duration.has_value())
+                if (auto duration = fn())
+                    time_point += duration.value();
+                else
                     return;
-                time_point += duration.value();
             }
         }
 

--- a/src/include/rpp/schedulers/immediate_scheduler.h
+++ b/src/include/rpp/schedulers/immediate_scheduler.h
@@ -22,13 +22,11 @@
 
 #pragma once
 
-#include "rpp/subscription.h"
-
-#include <rpp/schedulers/fwd.h>
+#include <rpp/subscription.h>
 #include <rpp/schedulers/constraints.h>
+#include <rpp/schedulers/fwd.h>
 
 #include <chrono>
-#include <concepts>
 #include <thread>
 
 namespace rpp::schedulers
@@ -42,12 +40,12 @@ public:
         worker(rpp::subscription sub)
             : m_sub{std::move(sub)} {}
 
-        void schedule(const constraint::schedulable_fn auto& fn)
+        void schedule(const constraint::schedulable_fn auto& fn) const
         {
             schedule(std::chrono::high_resolution_clock::now(), fn);
         }
 
-        void schedule(time_point time_point, const constraint::schedulable_fn auto& fn)
+        void schedule(time_point time_point, const constraint::schedulable_fn auto& fn) const
         {
             while (m_sub.is_subscribed())
             {
@@ -58,6 +56,9 @@ public:
                 time_point += duration.value();
             }
         }
+
+        worker*       operator->() { return this; }
+        const worker* operator->() const { return this; }
     private:
         rpp::subscription m_sub;
     };

--- a/src/include/rpp/schedulers/immediate_scheduler.h
+++ b/src/include/rpp/schedulers/immediate_scheduler.h
@@ -65,7 +65,7 @@ public:
 
     static worker create_worker(rpp::subscription sub = {})
     {
-        return worker{ sub };
+        return worker{sub};
     }
 };
 } // namespace rpp::schedulers

--- a/src/include/rpp/schedulers/immediate_scheduler.h
+++ b/src/include/rpp/schedulers/immediate_scheduler.h
@@ -31,6 +31,9 @@
 
 namespace rpp::schedulers
 {
+/**
+ * \brief immediately calls provided schedulable or waits for time_point (in the caller-thread)
+ */
 class immediate final : public details::scheduler_tag
 {
 public:

--- a/src/include/rpp/schedulers/new_thread_scheduler.h
+++ b/src/include/rpp/schedulers/new_thread_scheduler.h
@@ -1,0 +1,152 @@
+// MIT License
+// 
+// Copyright (c) 2022 Aleksey Loginov
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <rpp/subscription.h>
+#include <rpp/schedulers/constraints.h>
+#include <rpp/schedulers/fwd.h>
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+namespace rpp::schedulers
+{
+    class schedulable
+    {
+    public:
+        schedulable(time_point time_point, size_t id, constraint::schedulable_fn auto&& fn)
+            : m_time_point{ time_point }
+            , m_id{ id }
+            , m_function{ std::forward<decltype(fn)>(fn) } {}
+
+        schedulable(const schedulable& other)                = default;
+        schedulable(schedulable&& other) noexcept            = default;
+        schedulable& operator=(const schedulable& other)     = default;
+        schedulable& operator=(schedulable&& other) noexcept = default;
+
+        bool operator<(const schedulable& other) const
+        {
+            if (m_time_point != other.m_time_point)
+                return m_time_point > other.m_time_point;
+            return m_id > other.m_id;
+        }
+
+        time_point                           GetTimePoint() const { return m_time_point; }
+        std::function<optional_duration()>&& ExtractFunction() const { return std::move(m_function); }
+
+    private:
+        time_point                         m_time_point;
+        size_t                             m_id;
+        mutable std::function<optional_duration()> m_function;
+    };
+
+    class new_thread final : public details::scheduler_tag
+    {
+    public:
+        class worker
+        {
+        public:
+            worker(rpp::subscription&& sub)
+                : m_sub{std::move(sub)}
+                , m_thread{std::bind_front(&worker::data_thread, this)} {}
+
+            ~worker()
+            {
+                if (m_thread.joinable())
+                {
+                    m_thread.request_stop();
+                    m_cv.notify_one();
+                    m_thread.join();
+                }
+            }
+
+            void schedule(constraint::schedulable_fn auto&& fn)
+            {
+                schedule(std::chrono::high_resolution_clock::now(), std::forward<decltype(fn)>(fn));
+            }
+
+            void schedule(time_point time_point, constraint::schedulable_fn auto&& fn)
+            {
+                if (!m_sub.is_subscribed())
+                    return;
+
+                {
+                    std::lock_guard lock{ m_mutex };
+                    m_queue.emplace(time_point, ++m_current_id, std::forward<decltype(fn)>(fn));
+                }
+                m_cv.notify_one();
+            }
+        private:
+            void data_thread(std::stop_token token)
+            {
+                while (!token.stop_requested())
+                {
+                    std::unique_lock lock{m_mutex};
+                    if (m_queue.empty())
+                    {
+                        m_cv.wait(lock);
+                    }
+                    else
+                    {
+                        m_cv.wait_until(lock, m_queue.top().GetTimePoint());
+                    }
+
+                    if (token.stop_requested())
+                        return;
+
+                    if (m_queue.empty() || m_queue.top().GetTimePoint() > clock_type::now())
+                        continue;
+
+                    auto fn         = std::move(m_queue.top().ExtractFunction());
+                    auto time_point = m_queue.top().GetTimePoint();
+                    m_queue.pop();
+
+                    lock.unlock();
+
+                    auto duration = fn();
+                    if (!duration.has_value())
+                        continue;
+                    time_point += duration.value();
+                    schedule(time_point, std::move(fn));
+                }
+            }
+
+        private:
+            rpp::subscription m_sub;
+            
+            std::mutex                       m_mutex{};
+            std::condition_variable          m_cv{};
+            std::priority_queue<schedulable> m_queue{};
+            size_t                           m_current_id{};
+            std::jthread                     m_thread{};
+        };
+
+        static auto create_worker(rpp::subscription sub = {})
+        {
+            return std::make_shared<worker>(std::move(sub));
+        }
+    };
+} // namespace rpp::schedulers

--- a/src/include/rpp/schedulers/new_thread_scheduler.h
+++ b/src/include/rpp/schedulers/new_thread_scheduler.h
@@ -66,6 +66,7 @@ private:
 
 /**
  * \brief scheduler which schedule execution of via queueing tasks to another thread with priority to time_point and order
+ * \details Creates new thread for each "create_worker" call. Any scheduled task will be queued to created thread for execution with respect to time_point and number of task
  */
 class new_thread final : public details::scheduler_tag
 {

--- a/src/include/rpp/schedulers/new_thread_scheduler.h
+++ b/src/include/rpp/schedulers/new_thread_scheduler.h
@@ -64,6 +64,9 @@ private:
     mutable std::function<optional_duration()> m_function;
 };
 
+/**
+ * \brief scheduler which schedule execution of via queueing tasks to another thread with priority to time_point and order
+ */
 class new_thread final : public details::scheduler_tag
 {
 public:

--- a/src/include/rpp/schedulers/new_thread_scheduler.h
+++ b/src/include/rpp/schedulers/new_thread_scheduler.h
@@ -27,6 +27,7 @@
 #include <rpp/schedulers/fwd.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <queue>
@@ -34,119 +35,118 @@
 
 namespace rpp::schedulers
 {
-    class schedulable
+class schedulable
+{
+public:
+    schedulable(time_point time_point, size_t id, constraint::schedulable_fn auto&& fn)
+        : m_time_point{time_point}
+        , m_id{id}
+        , m_function{std::forward<decltype(fn)>(fn)} {}
+
+    schedulable(const schedulable& other)                = default;
+    schedulable(schedulable&& other) noexcept            = default;
+    schedulable& operator=(const schedulable& other)     = default;
+    schedulable& operator=(schedulable&& other) noexcept = default;
+
+    bool operator<(const schedulable& other) const
+    {
+        return std::tie(m_time_point, m_id) > std::tie(other.m_time_point, other.m_id);
+    }
+
+    time_point                           GetTimePoint() const { return m_time_point; }
+    std::function<optional_duration()>&& ExtractFunction() const { return std::move(m_function); }
+
+private:
+    time_point                                 m_time_point;
+    size_t                                     m_id;
+    mutable std::function<optional_duration()> m_function;
+};
+
+class new_thread final : public details::scheduler_tag
+{
+public:
+    class worker
     {
     public:
-        schedulable(time_point time_point, size_t id, constraint::schedulable_fn auto&& fn)
-            : m_time_point{ time_point }
-            , m_id{ id }
-            , m_function{ std::forward<decltype(fn)>(fn) } {}
-
-        schedulable(const schedulable& other)                = default;
-        schedulable(schedulable&& other) noexcept            = default;
-        schedulable& operator=(const schedulable& other)     = default;
-        schedulable& operator=(schedulable&& other) noexcept = default;
-
-        bool operator<(const schedulable& other) const
+        worker(rpp::subscription&& sub)
+            : m_sub{std::move(sub)}
+            , m_thread{std::bind_front(&worker::data_thread, this)}
         {
-            if (m_time_point != other.m_time_point)
-                return m_time_point > other.m_time_point;
-            return m_id > other.m_id;
+            //sub.add([&]
+            //{
+            //    m_thread.join();
+            //});
         }
 
-        time_point                           GetTimePoint() const { return m_time_point; }
-        std::function<optional_duration()>&& ExtractFunction() const { return std::move(m_function); }
+        void schedule(constraint::schedulable_fn auto&& fn)
+        {
+            schedule(std::chrono::high_resolution_clock::now(), std::forward<decltype(fn)>(fn));
+        }
+
+        void schedule(time_point time_point, constraint::schedulable_fn auto&& fn)
+        {
+            if (!m_sub.is_subscribed())
+                return;
+
+            {
+                std::lock_guard lock{ m_mutex };
+                m_queue.emplace(time_point, ++m_current_id, std::forward<decltype(fn)>(fn));
+            }
+            m_cv.notify_one();
+        }
 
     private:
-        time_point                         m_time_point;
-        size_t                             m_id;
-        mutable std::function<optional_duration()> m_function;
-    };
-
-    class new_thread final : public details::scheduler_tag
-    {
-    public:
-        class worker
+        void data_thread(std::stop_token token)
         {
-        public:
-            worker(rpp::subscription&& sub)
-                : m_sub{std::move(sub)}
-                , m_thread{std::bind_front(&worker::data_thread, this)} {}
-
-            ~worker()
+            auto condition = [&]() { return !m_queue.empty() && m_queue.top().GetTimePoint() <= clock_type::now(); };
+            std::function<optional_duration()> fn{};
+            time_point time_point{};
+            while (!token.stop_requested())
             {
-                if (m_thread.joinable())
-                {
-                    m_thread.request_stop();
-                    m_cv.notify_one();
-                    m_thread.join();
-                }
-            }
-
-            void schedule(constraint::schedulable_fn auto&& fn)
-            {
-                schedule(std::chrono::high_resolution_clock::now(), std::forward<decltype(fn)>(fn));
-            }
-
-            void schedule(time_point time_point, constraint::schedulable_fn auto&& fn)
-            {
-                if (!m_sub.is_subscribed())
-                    return;
-
-                {
-                    std::lock_guard lock{ m_mutex };
-                    m_queue.emplace(time_point, ++m_current_id, std::forward<decltype(fn)>(fn));
-                }
-                m_cv.notify_one();
-            }
-        private:
-            void data_thread(std::stop_token token)
-            {
-                while (!token.stop_requested())
                 {
                     std::unique_lock lock{m_mutex};
                     if (m_queue.empty())
                     {
-                        m_cv.wait(lock);
+                        if (!m_cv.wait(lock, token, condition))
+                            continue;
                     }
                     else
                     {
-                        m_cv.wait_until(lock, m_queue.top().GetTimePoint());
+                        if (!m_cv.wait_until(lock, token, m_queue.top().GetTimePoint(), condition))
+                            continue;
                     }
 
                     if (token.stop_requested())
                         return;
 
-                    if (m_queue.empty() || m_queue.top().GetTimePoint() > clock_type::now())
-                        continue;
-
-                    auto fn         = std::move(m_queue.top().ExtractFunction());
-                    auto time_point = m_queue.top().GetTimePoint();
+                    fn         = std::move(m_queue.top().ExtractFunction());
+                    time_point = m_queue.top().GetTimePoint();
                     m_queue.pop();
+                }
 
-                    lock.unlock();
-
-                    auto duration = fn();
-                    if (!duration.has_value())
-                        continue;
+                auto duration = fn();
+                if (duration.has_value())
+                {
                     time_point += duration.value();
                     schedule(time_point, std::move(fn));
                 }
+                fn = {};
             }
-
-        private:
-            rpp::subscription m_sub;
-            
-            std::mutex                       m_mutex{};
-            std::condition_variable          m_cv{};
-            std::priority_queue<schedulable> m_queue{};
-            size_t                           m_current_id{};
-            std::jthread                     m_thread{};
-        };
-
-        static auto create_worker(rpp::subscription sub = {})
-        {
-            return std::make_shared<worker>(std::move(sub));
         }
+
+    private:
+        rpp::subscription m_sub;
+
+        std::mutex                       m_mutex{};
+        std::condition_variable_any      m_cv{};
+        std::priority_queue<schedulable> m_queue{};
+        size_t                           m_current_id{};
+        std::jthread                     m_thread{};
     };
+
+    static auto create_worker(rpp::subscription sub = {})
+    {
+        return std::make_shared<worker>(std::move(sub));
+    }
+};
 } // namespace rpp::schedulers

--- a/src/include/rpp/schedulers/schedulable.h
+++ b/src/include/rpp/schedulers/schedulable.h
@@ -22,4 +22,10 @@
 
 #pragma once
 
-#include <rpp/operators/map.h>
+namespace rpp
+{
+struct schedulable
+{
+    
+};
+} // namespace rpp

--- a/src/include/rpp/subscribers/dynamic_subscriber.h
+++ b/src/include/rpp/subscribers/dynamic_subscriber.h
@@ -46,13 +46,13 @@ template<constraint::observer TObs>
 dynamic_subscriber(TObs observer) -> dynamic_subscriber<utils::extract_observer_type_t<TObs>>;
 
 template<constraint::observer TObs>
-dynamic_subscriber(subscription, TObs observer) -> dynamic_subscriber<utils::extract_observer_type_t<TObs>>;
+dynamic_subscriber(composite_subscription, TObs observer) -> dynamic_subscriber<utils::extract_observer_type_t<TObs>>;
 
 template<typename T, typename Obs>
 dynamic_subscriber(specific_subscriber<T, Obs>) -> dynamic_subscriber<T>;
 
 template<typename OnNext, typename ...Args>
-dynamic_subscriber(subscription, OnNext, Args...) -> dynamic_subscriber<std::decay_t<utils::function_argument_t<OnNext>>>;
+dynamic_subscriber(composite_subscription, OnNext, Args...) -> dynamic_subscriber<std::decay_t<utils::function_argument_t<OnNext>>>;
 
 template<typename OnNext, typename ...Args>
 dynamic_subscriber(OnNext, Args ...) -> dynamic_subscriber<std::decay_t<utils::function_argument_t<OnNext>>>;

--- a/src/include/rpp/subscribers/specific_subscriber.h
+++ b/src/include/rpp/subscribers/specific_subscriber.h
@@ -44,26 +44,26 @@ public:
         : details::subscriber_base<Type>{} { }
 
     specific_subscriber(const Observer& observer)
-        : specific_subscriber{subscription{}, observer} { }
+        : specific_subscriber{composite_subscription{}, observer} { }
 
     specific_subscriber(Observer&& observer)
-        : specific_subscriber{subscription{}, std::move(observer)} { }
+        : specific_subscriber{ composite_subscription{}, std::move(observer)} { }
 
-    specific_subscriber(const subscription& sub, const Observer& observer)
+    specific_subscriber(const composite_subscription& sub, const Observer& observer)
         : details::subscriber_base<Type>{sub}
         , m_observer{observer} { }
 
-    specific_subscriber(const subscription& sub, Observer&& observer)
+    specific_subscriber(const composite_subscription& sub, Observer&& observer)
         : details::subscriber_base<Type>{sub}
         , m_observer{std::move(observer)} { }
 
     //********************* Construct by actions *********************//
     template<typename ...Types>
     specific_subscriber(Types&&...vals) requires std::constructible_from<Observer, Types...>
-        : specific_subscriber{subscription{}, std::forward<Types>(vals)...} {}
+        : specific_subscriber{ composite_subscription{}, std::forward<Types>(vals)...} {}
 
     template<typename ...Types>
-    specific_subscriber(const subscription& sub, Types&&...vals) requires std::constructible_from<Observer, Types...>
+    specific_subscriber(const composite_subscription& sub, Types&&...vals) requires std::constructible_from<Observer, Types...>
         : details::subscriber_base<Type>{sub}
         , m_observer{std::forward<Types>(vals)...} {}
 
@@ -107,12 +107,12 @@ template<constraint::observer TObs>
 specific_subscriber(TObs observer) -> specific_subscriber<utils::extract_observer_type_t<TObs>, TObs>;
 
 template<constraint::observer TObs>
-specific_subscriber(subscription, TObs observer) -> specific_subscriber<utils::extract_observer_type_t<TObs>, TObs>;
+specific_subscriber(composite_subscription, TObs observer) -> specific_subscriber<utils::extract_observer_type_t<TObs>, TObs>;
 
 template<typename OnNext,
          typename ...Args,
          typename Type = std::decay_t<utils::function_argument_t<OnNext>>>
-specific_subscriber(subscription, OnNext, Args ...) -> specific_subscriber<Type, details::deduce_specific_observer_type_t<Type, OnNext, Args...>>;
+specific_subscriber(composite_subscription, OnNext, Args ...) -> specific_subscriber<Type, details::deduce_specific_observer_type_t<Type, OnNext, Args...>>;
 
 template<typename OnNext,
          typename ...Args,
@@ -131,7 +131,7 @@ auto make_specific_subscriber(Args&& ...args) -> specific_subscriber<Type, declt
 }
 
 template<typename Type, typename ...Args>
-auto make_specific_subscriber(constraint::decayed_same_as<subscription> auto&& sub, Args&& ...args)  -> specific_subscriber<Type, decltype(rpp::make_specific_observer<Type>(std::declval<Args>()...))>
+auto make_specific_subscriber(constraint::decayed_same_as<composite_subscription> auto&& sub, Args&& ...args)  -> specific_subscriber<Type, decltype(rpp::make_specific_observer<Type>(std::declval<Args>()...))>
 {
     auto observer = rpp::make_specific_observer<Type>(std::forward<Args>(args)...);
     return rpp::specific_subscriber<Type, decltype(observer)>(std::forward<decltype(sub)>(sub), std::move(observer));

--- a/src/include/rpp/subscribers/subscriber_base.h
+++ b/src/include/rpp/subscribers/subscriber_base.h
@@ -22,8 +22,9 @@
 
 #pragma once
 
-#include <rpp/subscription.h>
 #include <rpp/observers/interface_observer.h>
+#include <rpp/subscriptions/composite_subscription.h>
+#include <rpp/subscriptions/subscription_guard.h>
 
 namespace rpp::details
 {
@@ -35,14 +36,14 @@ struct subscriber_tag {};
  */
 template<constraint::decayed_type Type>
 class subscriber_base
-    : public interface_observer<Type>
-    , public subscriber_tag
+        : public interface_observer<Type>
+        , public subscriber_tag
 {
 public:
-    subscriber_base(const subscription& subscription)
+    subscriber_base(const composite_subscription& subscription)
         : m_subscription{subscription} {}
 
-    subscriber_base(subscription&& subscription = {})
+    subscriber_base(composite_subscription&& subscription = composite_subscription{})
         : m_subscription{std::move(subscription)} {}
 
     subscriber_base(const subscriber_base&)     = default;
@@ -96,7 +97,7 @@ public:
         on_completed_impl();
     }
 
-    const subscription& get_subscription() const
+    const composite_subscription& get_subscription() const
     {
         return m_subscription;
     }
@@ -118,6 +119,6 @@ protected:
     virtual void on_completed_impl() const = 0;
 
 private:
-    subscription m_subscription{};
+    composite_subscription m_subscription{};
 };
 } // namespace rpp::details

--- a/src/include/rpp/subscriptions/callback_subscription.h
+++ b/src/include/rpp/subscriptions/callback_subscription.h
@@ -30,6 +30,9 @@
 
 namespace rpp
 {
+/**
+ * \brief Subscription which invoke callbable during unsubscribe
+ */
 class callback_subscription final : public subscription_base
 {
 public:

--- a/src/include/rpp/subscriptions/composite_subscription.h
+++ b/src/include/rpp/subscriptions/composite_subscription.h
@@ -110,11 +110,11 @@ private:
 
     private:
         enum class DepsState : uint8_t
-		{
-			None,//< default state
-			Add, //< set it during adding new element into deps. After success -> FallBack to None
-			Unsubscribed //< permanent state after unsubscribe
-		};
+        {
+            None,        //< default state
+            Add,         //< set it during adding new element into deps. After success -> FallBack to None
+            Unsubscribed //< permanent state after unsubscribe
+        };
 
         std::atomic<DepsState>         m_state{DepsState::None};
         std::vector<subscription_base> m_deps{};

--- a/src/include/rpp/subscriptions/composite_subscription.h
+++ b/src/include/rpp/subscriptions/composite_subscription.h
@@ -102,9 +102,6 @@ private:
                     m_deps.clear();
                     return;
                 }
-
-                if (expected == DepsState::Unsubscribed)
-                    return;
             }
         }
 

--- a/src/include/rpp/subscriptions/composite_subscription.h
+++ b/src/include/rpp/subscriptions/composite_subscription.h
@@ -31,6 +31,9 @@
 
 namespace rpp
 {
+/**
+ * \brief rpp::subscription_base with ability to add some dependent subscriptions as a part of this one: in case of initiation of unsubscribe of this subscription, then any dependent subscriptions will be unsubscribed too
+ */
 class composite_subscription final : public subscription_base
 {
 public:
@@ -38,12 +41,18 @@ public:
     explicit composite_subscription(const Subs&...subs)
         : subscription_base{std::make_shared<state>(std::vector<subscription_base>{subs...})} {}
 
+    /**
+     * \brief Add any other subscription to this as dependent
+     */
     subscription_base add(const subscription_base& sub) const
     {
         static_cast<state&>(get_state()).add(sub);
         return sub;
     }
 
+    /**
+     * \brief Add callback/function subscription to this as dependent
+     */
     subscription_base add(const callback_subscription& sub) const
     {
         return add(static_cast<const subscription_base&>(sub));

--- a/src/include/rpp/subscriptions/composite_subscription.h
+++ b/src/include/rpp/subscriptions/composite_subscription.h
@@ -24,6 +24,7 @@
 
 #include <rpp/subscriptions/subscription_base.h>
 #include <rpp/subscriptions/callback_subscription.h>
+#include <rpp/utils/constraints.h>
 
 #include <algorithm>
 #include <mutex>
@@ -38,8 +39,11 @@ class composite_subscription final : public subscription_base
 {
 public:
     template<std::convertible_to<subscription_base> ...Subs>
-    explicit composite_subscription(const Subs&...subs)
+    explicit composite_subscription(const Subs&...subs) requires (!rpp::constraint::variadic_is_same_type< composite_subscription>)
         : subscription_base{std::make_shared<state>(std::vector<subscription_base>{subs...})} {}
+
+    composite_subscription(const composite_subscription&)     = default;
+    composite_subscription(composite_subscription&&) noexcept = default;
 
     /**
      * \brief Add any other subscription to this as dependent

--- a/src/include/rpp/subscriptions/composite_subscription.h
+++ b/src/include/rpp/subscriptions/composite_subscription.h
@@ -1,0 +1,110 @@
+// MIT License
+// 
+// Copyright (c) 2022 Aleksey Loginov
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <rpp/subscriptions/subscription_base.h>
+#include <rpp/subscriptions/callback_subscription.h>
+
+#include <algorithm>
+#include <mutex>
+#include <vector>
+
+namespace rpp
+{
+class composite_subscription final : public subscription_base
+{
+public:
+    template<std::convertible_to<subscription_base> ...Subs>
+    explicit composite_subscription(const Subs&...subs)
+        : subscription_base{std::make_shared<state>(std::vector<subscription_base>{subs...})} {}
+
+    subscription_base add(const subscription_base& sub) const
+    {
+        static_cast<state&>(get_state()).add(sub);
+        return sub;
+    }
+
+    subscription_base add(const callback_subscription& sub) const
+    {
+        return add(static_cast<const subscription_base&>(sub));
+    }
+
+private:
+    class state final : public details::subscription_state
+    {
+    public:
+        state(std::vector<subscription_base>&& deps)
+            : m_deps{std::move(deps)} {}
+
+        void add(const subscription_base& sub)
+        {
+            while (true)
+            {
+                DepsState expected{DepsState::None};
+                if (m_state.compare_exchange_strong(expected, DepsState::Add))
+                {
+                    m_deps.push_back(sub);
+
+                    m_state.store(DepsState::None);
+                    return;
+                }
+
+                if (expected == DepsState::Unsubscribed)
+                {
+                    sub.unsubscribe();
+                    return;
+                }
+            }
+        }
+
+    private:
+        void on_unsubscribe() override
+        {
+            while (true)
+            {
+                DepsState expected{DepsState::None};
+                if (m_state.compare_exchange_strong(expected, DepsState::Unsubscribed))
+                {
+                    std::ranges::for_each(m_deps, &subscription_base::unsubscribe);
+                    m_deps.clear();
+                    return;
+                }
+
+                if (expected == DepsState::Unsubscribed)
+                    return;
+            }
+        }
+
+    private:
+        enum class DepsState : uint8_t
+		{
+			None,//< default state
+			Add, //< set it during adding new element into deps. After success -> FallBack to None
+			Unsubscribed //< permanent state after unsubscribe
+		};
+
+        std::atomic<DepsState>         m_state{DepsState::None};
+        std::vector<subscription_base> m_deps{};
+    };
+};
+} // namespace rpp

--- a/src/include/rpp/subscriptions/details/subscription_state.h
+++ b/src/include/rpp/subscriptions/details/subscription_state.h
@@ -46,10 +46,8 @@ public:
 
     void unsubscribe()
     {
-        if (!m_is_subscribed.exchange(false))
-            return;
-
-        on_unsubscribe();
+        if (m_is_subscribed.exchange(false))
+            on_unsubscribe();
     }
 
 protected:

--- a/src/include/rpp/subscriptions/details/subscription_state.h
+++ b/src/include/rpp/subscriptions/details/subscription_state.h
@@ -26,6 +26,10 @@
 
 namespace rpp::details
 {
+/**
+ * \brief Base implementation of subscription state used under-hood for rpp::subscription_base and its childs
+ * \details subscription_state uses atomic_bool to track current state of the subscription and where unsubscribe should be called or not. Used as base implementation for more complicated states
+ */
 class subscription_state
 {
 public:

--- a/src/include/rpp/subscriptions/details/subscription_state.h
+++ b/src/include/rpp/subscriptions/details/subscription_state.h
@@ -1,6 +1,6 @@
 // MIT License
 // 
-// Copyright (c) 2021 Aleksey Loginov
+// Copyright (c) 2022 Aleksey Loginov
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,36 @@
 
 #pragma once
 
-#include <rpp/observables/fwd.h>
-#include <rpp/observers/fwd.h>
-#include <rpp/sources/fwd.h>
-#include <rpp/subscribers/fwd.h>
-#include <rpp/operators/fwd.h>
-#include <rpp/subscriptions/fwd.h>
+#include <atomic>
+
+namespace rpp::details
+{
+class subscription_state
+{
+public:
+    subscription_state()          = default;
+    virtual ~subscription_state() = default;
+
+    subscription_state(const subscription_state&)     = delete;
+    subscription_state(subscription_state&&) noexcept = delete;
+
+    [[nodiscard]] bool is_subscribed() const
+    {
+        return m_is_subscribed.load();
+    }
+
+    void unsubscribe()
+    {
+        if (!m_is_subscribed.exchange(false))
+            return;
+
+        on_unsubscribe();
+    }
+
+protected:
+    virtual void on_unsubscribe() {}
+
+private:
+    std::atomic_bool m_is_subscribed{true};
+};
+} // namespace rpp::details

--- a/src/include/rpp/subscriptions/fwd.h
+++ b/src/include/rpp/subscriptions/fwd.h
@@ -22,47 +22,7 @@
 
 #pragma once
 
-#include <atomic>
-#include <memory>
-
 namespace rpp
 {
-class subscription
-{
-public:
-    subscription() : m_state{std::make_shared<state>()} {}
-
-    [[nodiscard]] bool is_subscribed() const
-    {
-        return m_state && m_state->is_subscribed.load();
-    }
-
-    void unsubscribe() const
-    {
-        if (m_state)
-            m_state->is_subscribed.store(false);
-    }
-
-private:
-    struct state
-    {
-        std::atomic_bool is_subscribed{true};
-    };
-
-    std::shared_ptr<state> m_state{};
-};
-
-/**
- * \brief guard over subscription to auto-unsubscribe during destructor
- */
-class subscription_guard
-{
-public:
-    subscription_guard(const subscription& sub)
-        : m_sub{ sub } {}
-
-    ~subscription_guard() { m_sub.unsubscribe(); }
-private:
-    subscription m_sub;
-};
+class composite_subscription;
 } // namespace rpp

--- a/src/include/rpp/subscriptions/subscription_base.h
+++ b/src/include/rpp/subscriptions/subscription_base.h
@@ -1,6 +1,6 @@
 // MIT License
 // 
-// Copyright (c) 2021 Aleksey Loginov
+// Copyright (c) 2022 Aleksey Loginov
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,38 @@
 
 #pragma once
 
-#include <rpp/observables/fwd.h>
-#include <rpp/observers/fwd.h>
-#include <rpp/sources/fwd.h>
-#include <rpp/subscribers/fwd.h>
-#include <rpp/operators/fwd.h>
-#include <rpp/subscriptions/fwd.h>
+#include <rpp/subscriptions/details/subscription_state.h>
+
+#include <atomic>
+#include <memory>
+
+namespace rpp
+{
+class subscription_base
+{
+protected:
+    subscription_base(std::shared_ptr<details::subscription_state> state)
+        : m_state{std::move(state)} {}
+
+    details::subscription_state& get_state() const { return *m_state; }
+public:
+    subscription_base()
+        : m_state{std::make_shared<details::subscription_state>()} {}
+
+    virtual ~subscription_base() = default;
+
+    [[nodiscard]] bool is_subscribed() const
+    {
+        return m_state->is_subscribed();
+    }
+
+    void unsubscribe() const
+    {
+        m_state->unsubscribe();
+    }
+
+private:
+    std::shared_ptr<details::subscription_state> m_state{};
+};
+
+} // namespace rpp

--- a/src/include/rpp/subscriptions/subscription_base.h
+++ b/src/include/rpp/subscriptions/subscription_base.h
@@ -29,6 +29,9 @@
 
 namespace rpp
 {
+/**
+ * \brief Base subscription implementation used as base class/interface and core implementation for derrived subscriptions
+ */
 class subscription_base
 {
 protected:
@@ -42,11 +45,17 @@ public:
 
     virtual ~subscription_base() = default;
 
+    /**
+     * \brief indicates current status of subscription
+     */
     [[nodiscard]] bool is_subscribed() const
     {
         return m_state->is_subscribed();
     }
 
+    /**
+     * \brief initiates unsubscription process (if subscribed)
+     */
     void unsubscribe() const
     {
         m_state->unsubscribe();

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${TARGET}
     test_subscriber.cpp
     test_map.cpp
     test_schedulers.cpp
+    test_subscriptions.cpp
     
     test_lift.cpp
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${TARGET}
     test_observer.cpp
     test_subscriber.cpp
     test_map.cpp
+    test_schedulers.cpp
     
     test_lift.cpp
 

--- a/src/tests/benchmarks.cpp
+++ b/src/tests/benchmarks.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Observable construction", "[benchmark]")
 
 TEST_CASE("Observable subscribe #2", "[benchmark]")
 {
-    rpp::subscription subscription{};
+    rpp::composite_subscription subscription{};
     auto specific = MakeSpecificObservable();
     BENCHMARK("Specific observable subscribe lambda")
     {

--- a/src/tests/test_observable.cpp
+++ b/src/tests/test_observable.cpp
@@ -93,11 +93,11 @@ SCENARIO("Any observable can be subscribed from any type of subscription", "[obs
         WHEN("subscribe with dynamic_subscriber")
             validate_subscribe(rpp::dynamic_subscriber<int>{});
         WHEN("subscribe with subscription + specific_observer")
-            validate_subscribe(rpp::subscription{}, rpp::specific_observer<int>{});
+            validate_subscribe(rpp::composite_subscription{}, rpp::specific_observer<int>{});
         WHEN("subscribe with subscription + dynamic_observer")
-            validate_subscribe(rpp::subscription{}, rpp::dynamic_observer<int>{});
+            validate_subscribe(rpp::composite_subscription{}, rpp::dynamic_observer<int>{});
         WHEN("subscribe with subscription + lambda")
-            validate_subscribe(rpp::subscription{}, [](const int&){});
+            validate_subscribe(rpp::composite_subscription{}, [](const int&){});
     };
 
     GIVEN("specific_observable")

--- a/src/tests/test_schedulers.cpp
+++ b/src/tests/test_schedulers.cpp
@@ -88,7 +88,7 @@ SCENARIO("Immediate scheduler schedule task immediately")
             THEN("called twice immediately")
             {
                 std::vector<rpp::schedulers::time_point> executions{};
-                auto                                     diff = std::chrono::seconds{1};
+                std::chrono::milliseconds                diff = std::chrono::seconds{1};
 
                 worker->schedule([&call_count, &executions, &diff]() -> rpp::schedulers::optional_duration
                 {
@@ -99,7 +99,7 @@ SCENARIO("Immediate scheduler schedule task immediately")
                 });
 
                 REQUIRE(call_count == 2);
-                REQUIRE(executions[1] - executions[0] >= diff);
+                REQUIRE(executions[1] - executions[0] >= (diff - std::chrono::milliseconds(500)));
             }
         }
     }
@@ -202,7 +202,7 @@ SCENARIO("New thread scheduler schedules tasks into separate thread")
             THEN("called twice immediately")
             {
                 std::vector<rpp::schedulers::time_point> executions{};
-                auto                                     diff = std::chrono::seconds{1};
+                std::chrono::milliseconds                diff = std::chrono::seconds{1};
                 size_t                                   call_count{};
                 worker->schedule([&call_count, &executions, &diff]() -> rpp::schedulers::optional_duration
                 {
@@ -215,7 +215,7 @@ SCENARIO("New thread scheduler schedules tasks into separate thread")
                 std::this_thread::sleep_for(diff * 2);
 
                 REQUIRE(call_count == 2);
-                REQUIRE(executions[1] - executions[0] >= diff);
+                REQUIRE(executions[1] - executions[0] >= (diff-std::chrono::milliseconds(500))); 
             }
         }
     }

--- a/src/tests/test_schedulers.cpp
+++ b/src/tests/test_schedulers.cpp
@@ -1,0 +1,92 @@
+// MIT License
+// 
+// Copyright (c) 2022 Aleksey Loginov
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <catch2/catch_test_macros.hpp>
+#include <rpp/schedulers/immediate_scheduler.h>
+
+SCENARIO("Immediate scheduler schedule task immediately")
+{
+    GIVEN("immediate_scheduler")
+    {
+        auto scheduler = rpp::schedulers::immediate_scheduler{};
+
+        auto worker = scheduler.create_worker();
+        WHEN("scheduler without time and resheduling")
+        {
+            size_t call_count{};
+            worker.schedule([&call_count]() -> rpp::schedulers::optional_duration {++call_count; return {}; });
+            THEN("called once immediately")
+            {
+                CHECK(call_count == 1);
+            }
+        }
+        WHEN("scheduler without time with scheduling")
+        {
+            size_t call_count{};
+            worker.schedule([&call_count]() -> rpp::schedulers::optional_duration
+            {
+                if (++call_count <= 1)
+                    return {{}};
+                return {};
+            });
+            THEN("called twice immediately")
+            {
+                CHECK(call_count == 2);
+            }
+		}
+		WHEN("scheduler with time")
+		{
+			size_t call_count{};
+            auto now = rpp::schedulers::clock_type::now();
+            rpp::schedulers::time_point execute_time{};
+			worker.schedule(rpp::schedulers::clock_type::now() + std::chrono::seconds{ 2 },
+				[&call_count, &execute_time]() -> rpp::schedulers::optional_duration
+				{
+					++call_count;
+                    execute_time = rpp::schedulers::clock_type::now();
+					return {};
+				});
+			THEN("called twice immediately")
+			{
+				REQUIRE(call_count == 1);
+                REQUIRE(execute_time - now >= std::chrono::seconds{ 2 });
+			}
+		}
+        WHEN("scheduler without time with scheduling")
+        {
+            size_t                                   call_count{};
+            std::vector<rpp::schedulers::time_point> executions{};
+            worker.schedule([&call_count, &executions]() -> rpp::schedulers::optional_duration
+                {
+                    executions.push_back(rpp::schedulers::clock_type::now());
+                    if (++call_count <= 1)
+                        return { std::chrono::seconds{3} };
+                    return {};
+                });
+            THEN("called twice immediately")
+            {
+                REQUIRE(call_count == 2);
+                REQUIRE(executions[1] - executions[0] >= std::chrono::seconds{ 3 });
+            }
+        }
+	}
+}

--- a/src/tests/test_subscriptions.cpp
+++ b/src/tests/test_subscriptions.cpp
@@ -1,0 +1,112 @@
+// MIT License
+// 
+// Copyright (c) 2022 Aleksey Loginov
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <rpp/subscriptions/subscription_base.h>
+#include <rpp/subscriptions/callback_subscription.h>
+#include <rpp/subscriptions/composite_subscription.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("subscriptions works as expected")
+{
+    GIVEN("subscription")
+    {
+        rpp::subscription_base sub{};
+        REQUIRE(sub.is_subscribed());
+        WHEN("call unsubscribe")
+        {
+            sub.unsubscribe();
+            THEN("state changes")
+            {
+                REQUIRE(sub.is_subscribed() == false);
+            }
+        }
+    }
+
+    GIVEN("callback subscription")
+    {
+        size_t                     call_count{};
+        rpp::callback_subscription sub{[&]() { ++call_count; }};
+        REQUIRE(sub.is_subscribed());
+
+        WHEN("call unsubscribe multiple times")
+        {
+            for (size_t i = 0; i < 10; ++i)
+                sub.unsubscribe();
+
+            THEN("state changes and callback called once")
+            {
+                REQUIRE(sub.is_subscribed() == false);
+                REQUIRE(call_count == 1);
+            }
+        }
+    }
+
+    GIVEN("composite subscription")
+    {
+        rpp::subscription_base     sub{};
+        size_t                     call_count{};
+        rpp::callback_subscription callback_subscription{[&]() { ++call_count; }};
+
+        rpp::composite_subscription composite{sub, callback_subscription};
+
+        REQUIRE(composite.is_subscribed());
+
+        WHEN("call unsubscribe multiple times")
+        {
+            composite.unsubscribe();
+            composite.unsubscribe();
+            composite.unsubscribe();
+
+            THEN("state changes for all dependents subscriptions too")
+            {
+                REQUIRE(composite.is_subscribed() == false);
+                REQUIRE(sub.is_subscribed() == false);
+                REQUIRE(callback_subscription.is_subscribed() == false);
+                REQUIRE(call_count == 1);
+            }
+        }
+        WHEN("add new subscription and unsubscribe")
+        {
+            rpp::subscription_base new_sub{};
+            composite.add(new_sub);
+            composite.unsubscribe();
+
+            THEN("state changes for all dependents subscriptions too")
+            {
+                REQUIRE(new_sub.is_subscribed() == false);
+            }
+        }
+        WHEN("unsubscribe and add new subscription")
+        {
+            composite.unsubscribe();
+
+            rpp::subscription_base new_sub{};
+            composite.add(new_sub);
+
+            THEN("new sub unsubscribed immediately")
+            {
+                REQUIRE(new_sub.is_subscribed() == false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes:
- Create `rpp::schedulers::immediate` and `rpp::schedulers::new_thread`
- Split subscription to `rpp::composite_subscription`, `rpp::subscription_base` and `rpp::callback_subscription`