### PR TITLE
Open up submodule/catch2 for everyone.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/Catch2"]
 	path = submodules/Catch2
-	url = git@github.com:catchorg/Catch2.git
+	url = https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
Allow developers who don't have permission to ssh catch2 repo to configure the project.