### PR TITLE
Fix CMake config so that IDEs could resolve include semantics <>

### DIFF
--- a/src/rpp/CMakeLists.txt
+++ b/src/rpp/CMakeLists.txt
@@ -10,13 +10,8 @@
 
 file(GLOB_RECURSE FILES "*.hpp")
 
-if(${CMAKE_VERSION} VERSION_LESS "3.19.0")
-  add_library(rpp INTERFACE)
-else()
-  add_library(rpp INTERFACE ${FILES})
-endif()
+add_library(rpp INTERFACE)
 
-target_sources(rpp INTERFACE ${FILES})
 target_include_directories(rpp INTERFACE .)
 target_link_libraries(rpp INTERFACE coverage_config Threads::Threads)
 


### PR DESCRIPTION
Both VSCode and CLion can't resolve the inter dependencies via `#include <>` semantics because we add `${FILES}` as sources. Source with `${FILES}` overrides the `-I` for the target and hence no IDEs could locate the imports.

e.g. IDEs can resolve `#include "rpp.hpp" // no rpp prefix` but not for `#include <rpp/rpp.hpp>`.

Alternatively, we could replace `<>` with `""`, which touches more files. We think this is a minimum changes that works.