### PR TITLE
Support gitignore to wider IDEs/build-systems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,58 @@
 _build/*
 gen_docs/*
 gen_images/*
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+*.dSYM
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# VSCode
+.vscode
+*.code-workspace
+*.workspace
+
+# CMake
+*.cmake
+build
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+DartConfiguration.tcl
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps


### PR DESCRIPTION
I use [VSCode C++ Packs](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack) and found this `.gitignore` works pretty well for VSCode and CLion to ignore the generated files.