### PR TITLE
Add subscription check before activating the OnSubscribeFn of an observable

### DIFF
--- a/src/rpp/rpp/observables/specific_observable.hpp
+++ b/src/rpp/rpp/observables/specific_observable.hpp
@@ -100,7 +100,10 @@ private:
     {
         try
         {
-            m_state(subscriber);
+            if (subscriber.is_subscribed())
+            {
+                m_state(subscriber);
+            }
         }
         catch (...)
         {


### PR DESCRIPTION
We’d like to not activate the observable when it’s subscribed to a dead subscriber for `flat_map()` or `switch_map()` operators.