### PR TITLE
Empty base optimization

### DIFF
--- a/src/rpp/rpp/defs.hpp
+++ b/src/rpp/rpp/defs.hpp
@@ -1,0 +1,17 @@
+//                   ReactivePlusPlus library
+// 
+//           Copyright Aleksey Loginov 2022 - present.
+//  Distributed under the Boost Software License, Version 1.0.
+//     (See accompanying file LICENSE_1_0.txt or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+// 
+//  Project home: https://github.com/victimsnino/ReactivePlusPlus
+
+#pragma once
+
+// MSVC has bad support for the empty base classes, but provides specificator to enable full support. GCC/Clang works as expected
+#if defined(_MSC_VER) && _MSC_FULL_VER >= 190023918
+#  define RPP_EMPTY_BASES __declspec(empty_bases)
+#else
+#  define RPP_EMPTY_BASES
+#endif

--- a/src/rpp/rpp/observables/blocking_observable.hpp
+++ b/src/rpp/rpp/observables/blocking_observable.hpp
@@ -15,6 +15,7 @@
 
 #include <rpp/observables/details/member_overload.hpp> // overload operators
 #include <rpp/operators/fwd.hpp>                    // forwarding of member_overaloads
+#include <rpp/defs.hpp>                             // RPP_EMPTY_BASES
 
 
 #include <future>
@@ -28,7 +29,7 @@ namespace rpp
  * \ingroup observables
  */
 template<constraint::decayed_type Type, constraint::observable_of_type<Type> OriginalObservable>
-class blocking_observable final : public details::member_overload<Type, blocking_observable<Type, OriginalObservable>, details::subscribe_tag>
+class RPP_EMPTY_BASES blocking_observable final : public details::member_overload<Type, blocking_observable<Type, OriginalObservable>, details::subscribe_tag>
 {
 public:
     blocking_observable(const OriginalObservable& original)

--- a/src/rpp/rpp/observables/connectable_observable.hpp
+++ b/src/rpp/rpp/observables/connectable_observable.hpp
@@ -14,6 +14,8 @@
 #include <rpp/subjects/constraints.hpp>                 // type of subject used
 #include <rpp/subjects/type_traits.hpp>                 // deduce observable type by subject type
 #include <rpp/subscriptions/composite_subscription.hpp> // lifetime
+#include <rpp/defs.hpp>                                 // RPP_EMPTY_BASES
+
 
 #include <memory>
 #include <mutex>
@@ -31,7 +33,7 @@ namespace rpp
 template<constraint::decayed_type                    Type,
          subjects::constraint::subject_of_type<Type> Subject,
          constraint::observable_of_type<Type>        OriginalObservable>
-class connectable_observable
+class RPP_EMPTY_BASES connectable_observable
     : public decltype(std::declval<Subject>().get_observable())
     , public details::member_overload<Type, connectable_observable<Type, Subject, OriginalObservable>, details::ref_count_tag>
 {

--- a/src/rpp/rpp/observables/interface_observable.hpp
+++ b/src/rpp/rpp/observables/interface_observable.hpp
@@ -16,14 +16,9 @@
 #include <rpp/operators/lift.hpp>                   // must-have operators
 #include <rpp/observables/blocking_observable.hpp>  // as_blocking
 
-#include <type_traits>
+#include <rpp/defs.hpp>                             // RPP_EMPTY_BASES
 
-// MSVC has bad support for the empty base clases, but provides specificator to enable full support. GCC/Clang works as expected
-#if defined(_MSC_VER) && _MSC_FULL_VER >= 190023918
-#  define RPP_EMPTY_BASES __declspec(empty_bases)
-#else
-#  define RPP_EMPTY_BASES
-#endif
+#include <type_traits>
 
 namespace rpp::details
 {

--- a/src/rpp/rpp/observables/interface_observable.hpp
+++ b/src/rpp/rpp/observables/interface_observable.hpp
@@ -18,6 +18,13 @@
 
 #include <type_traits>
 
+// MSVC has bad support for the empty base clases, but provides specificator to enable full support. GCC/Clang works as expected
+#if defined(_MSC_VER) && _MSC_FULL_VER >= 190023918
+#  define RPP_EMPTY_BASES __declspec(empty_bases)
+#else
+#  define RPP_EMPTY_BASES
+#endif
+
 namespace rpp::details
 {
 struct observable_tag {};
@@ -35,7 +42,7 @@ namespace rpp
 template<constraint::decayed_type Type>
 struct virtual_observable : public details::observable_tag
 {
-    virtual ~virtual_observable() = default;
+    //virtual ~virtual_observable() = default;
 };
 
 /**
@@ -44,7 +51,7 @@ struct virtual_observable : public details::observable_tag
  * \tparam SpecificObservable final type of observable inherited from this observable to successfully copy/move it
  */
 template<constraint::decayed_type Type, typename SpecificObservable>
-struct interface_observable
+struct RPP_EMPTY_BASES interface_observable
     : public virtual_observable<Type>
     , details::member_overload<Type, SpecificObservable, details::subscribe_tag>
     , details::member_overload<Type, SpecificObservable, details::lift_tag>
@@ -62,6 +69,7 @@ struct interface_observable
     , details::member_overload<Type, SpecificObservable, details::switch_on_next_tag>
 {
 public:
+
     /**
     * \brief The apply function to observable which returns observable of another type
     * \tparam OperatorFn type of function which applies to this observable

--- a/src/tests/test_observable.cpp
+++ b/src/tests/test_observable.cpp
@@ -251,7 +251,7 @@ SCENARIO("Verify copy when observer take const lvalue& from const lvalue&", "[ob
     TestObserverTypes<const copy_count_tracker&,false, true>("no copies", 0, 0);
 }
 
-SCENARIO("base observables")
+SCENARIO("base observables", "[observable]")
 {
     mock_observer<int> mock{ };
 
@@ -299,7 +299,7 @@ SCENARIO("base observables")
     }
 }
 
-SCENARIO("blocking observable")
+SCENARIO("blocking observable", "[observable]")
 {
     GIVEN("observable with wait")
     {
@@ -330,5 +330,21 @@ SCENARIO("blocking observable")
                 CHECK(mock.get_on_error_count() == 1);
             }
         }
+    }
+}
+
+TEST_CASE("Observable size should be equal to state + vtable", "[observable]")
+{
+    SECTION("specific_observable")
+    {
+        auto action     = [](const auto&) {};
+        auto observable = rpp::source::create<int>(action);
+        CHECK(sizeof(observable) == sizeof(action));
+    }
+
+    SECTION("dynamic_observable")
+    {
+        auto observable = rpp::source::create<int>([](const auto&) {}).as_dynamic<>();
+        CHECK(sizeof(observable) == sizeof(std::shared_ptr<int>));
     }
 }

--- a/src/tests/test_observable.cpp
+++ b/src/tests/test_observable.cpp
@@ -333,7 +333,7 @@ SCENARIO("blocking observable", "[observable]")
     }
 }
 
-TEST_CASE("Observable size should be equal to state + vtable", "[observable]")
+TEST_CASE("Observable size should be equal to size of state", "[observable]")
 {
     SECTION("specific_observable")
     {


### PR DESCRIPTION
Resolves issue with multiple base classess inheritance mentioned in #154. Currently gcc/clang makes perfect optimization out of the box, but MSVC requires extra flag