### PR TITLE
Fix IDE warning for std::make_shared on primitive types with clang

### DIFF
--- a/src/rpp/CMakeLists.txt
+++ b/src/rpp/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(rpp INTERFACE .)
 target_link_libraries(rpp INTERFACE coverage_config Threads::Threads)
 
 target_compile_features(rpp INTERFACE cxx_std_20)
+target_compile_options(rpp INTERFACE -fsized-deallocation)
 
 foreach(FILE ${FILES}) 
   get_filename_component(PARENT_DIR "${FILE}" PATH)


### PR DESCRIPTION
I use CLion/VSCode and the parser of the IDE seems to be based on clang. However, not all the clang language servers make  `-fsized-deallocation` as default compile-option. So the IDE complains about `__builtin_operator_delete` on `std::make_shared(...)`.

# Reference
- CLion discussion on this topic, [link](https://youtrack.jetbrains.com/issue/CPP-29091/In-template-call-to-builtinoperatordelete-selects-non-usual-deallocation-function-gcc-12).