### PR TITLE
[WIP] Update trampoline scheduler

### DIFF
--- a/src/rpp/rpp/observables/specific_observable.hpp
+++ b/src/rpp/rpp/observables/specific_observable.hpp
@@ -10,13 +10,13 @@
 
 #pragma once
 
+#include <rpp/defs.hpp>
 #include <rpp/observables/fwd.hpp>
 #include <rpp/observables/interface_observable.hpp>            // base_class
-#include <rpp/utils/operator_declaration.hpp>                  // for header include
+#include <rpp/schedulers/trampoline_scheduler.hpp>
 #include <rpp/subscribers/dynamic_subscriber.hpp>
+#include <rpp/utils/operator_declaration.hpp>                  // for header include
 #include <rpp/utils/utilities.hpp>                            // copy_assignable_callable
-
-#include <rpp/defs.hpp>
 
 #include <utility>
 
@@ -71,6 +71,8 @@ private:
     {
         try
         {
+            // take ownership over current thread as early as possible to delay all next "current_thread" schedulings. For  example, scheduling of emissions from "just" to delay it till whole chain is subscribed and ready to listened emissions
+            const auto drain_handle = rpp::schedulers::current_thread::ensure_queue_if_no_any_owner();
             m_state(subscriber);
         }
         catch (...)

--- a/src/rpp/rpp/observables/specific_observable.hpp
+++ b/src/rpp/rpp/observables/specific_observable.hpp
@@ -72,6 +72,10 @@ private:
         try
         {
             // take ownership over current thread as early as possible to delay all next "current_thread" schedulings. For  example, scheduling of emissions from "just" to delay it till whole chain is subscribed and ready to listened emissions
+            // For example, if we have
+            // rpp::source::just(rpp::schedulers::current_thread{}, 1,2).combine_latest(rpp::source::just(rpp::schedulers::current_thread{}, 1,2))
+            //
+            // then we expect to see emissions like (1,1) (2,1) (2,2) instead of (2,1) (2,2). TO do it we need to "take ownership" over queue to prevent ANY immediate schedulings from ANY next subscriptions
             if (rpp::schedulers::current_thread::is_queue_owned())
             {
                 m_state(subscriber);

--- a/src/rpp/rpp/observables/specific_observable.hpp
+++ b/src/rpp/rpp/observables/specific_observable.hpp
@@ -79,9 +79,10 @@ private:
             else
             {
                 // will be scheduled immediately -> reference can be passed
-                rpp::schedulers::current_thread::create_worker(subscriber.get_subscribtion()).schedule([&]
+                rpp::schedulers::current_thread::create_worker(subscriber.get_subscription()).schedule([&]
                 {
                     m_state(subscriber);
+                    return rpp::schedulers::optional_duration{};
                 });
             }
         }

--- a/src/rpp/rpp/schedulers/constraints.hpp
+++ b/src/rpp/rpp/schedulers/constraints.hpp
@@ -19,10 +19,10 @@ namespace rpp::schedulers::constraint
 {
 // returns std::nullopt in case of don't need to re-schedule schedulable or some duration which will be added to "now" and re-scheduled
 template<typename T>
-concept schedulable_fn = std::is_invocable_r_v<optional_duration, T>;
+concept schedulable_fn = std::invocable<T> && std::same_as<std::invoke_result_t<T>, optional_duration>;
 
 template<typename T>
-concept inner_schedulable_fn = std::is_invocable_r_v<void, T>;
+concept inner_schedulable_fn = std::invocable<T> && std::same_as<std::invoke_result_t<T>, void>;
 
 template<typename T>
 concept worker = std::is_base_of_v<details::worker_tag, std::decay_t<T>>;

--- a/src/rpp/rpp/schedulers/constraints.hpp
+++ b/src/rpp/rpp/schedulers/constraints.hpp
@@ -22,6 +22,9 @@ template<typename T>
 concept schedulable_fn = std::is_invocable_r_v<optional_duration, T>;
 
 template<typename T>
+concept inner_schedulable_fn = std::is_invocable_r_v<void, T>;
+
+template<typename T>
 concept worker = std::is_base_of_v<details::worker_tag, std::decay_t<T>>;
 
 template<typename T>

--- a/src/rpp/rpp/schedulers/details/queue_worker_state.hpp
+++ b/src/rpp/rpp/schedulers/details/queue_worker_state.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <rpp/schedulers/fwd.hpp>  // own forwarding
+#include <rpp/schedulers/constraints.hpp>
 
 #include <mutex>
 #include <condition_variable>
@@ -21,7 +22,7 @@ namespace rpp::schedulers::details
 class schedulable
 {
 public:
-    schedulable(time_point time_point, size_t id, std::invocable auto&& fn)
+    schedulable(time_point time_point, size_t id, constraint::inner_schedulable_fn auto&& fn)
         : m_time_point{time_point}
         , m_id{id}
         , m_function{std::forward<decltype(fn)>(fn)} {}
@@ -50,7 +51,7 @@ class queue_worker_state
 public:
     queue_worker_state() noexcept = default;
 
-    void emplace(time_point time_point, std::invocable auto&& fn)
+    void emplace(time_point time_point, constraint::inner_schedulable_fn auto&& fn)
     {
         emplace_safe(time_point, std::forward<decltype(fn)>(fn));
         m_cv.notify_one();
@@ -108,7 +109,7 @@ public:
     }
 
 private:
-    void emplace_safe(time_point time_point, std::invocable auto&& fn)
+    void emplace_safe(time_point time_point, constraint::inner_schedulable_fn auto&& fn)
     {
         std::lock_guard lock{ m_mutex };
         m_queue.emplace(time_point, ++m_current_id, std::forward<decltype(fn)>(fn));

--- a/src/rpp/rpp/schedulers/details/queue_worker_state.hpp
+++ b/src/rpp/rpp/schedulers/details/queue_worker_state.hpp
@@ -23,10 +23,10 @@ template<typename SchedulableFn>
 class schedulable
 {
 public:
-    schedulable(time_point time_point, size_t id, constraint::inner_schedulable_fn auto&& fn)
+    schedulable(time_point time_point, size_t id, SchedulableFn&& fn)
         : m_time_point{time_point}
         , m_id{id}
-        , m_function{std::forward<decltype(fn)>(fn)} {}
+        , m_function{std::move(fn)} {}
 
     schedulable(const schedulable& other)                = default;
     schedulable(schedulable&& other) noexcept            = default;
@@ -77,7 +77,7 @@ public:
         if (!is_any_ready_schedulable_unsafe())
             return false;
 
-        out = std::move(m_queue.top().extract_function());
+        out.emplace(std::move(m_queue.top().extract_function()));
         m_queue.pop();
         return true;
     }
@@ -97,7 +97,7 @@ public:
                                  std::bind_front(&queue_worker_state<SchedulableFn>::is_any_ready_schedulable_unsafe, this)))
                 continue;
 
-            out = std::move(m_queue.top().extract_function());
+            out.emplace(std::move(m_queue.top().extract_function()));
             m_queue.pop();
             return true;
         }

--- a/src/rpp/rpp/schedulers/details/queue_worker_state.hpp
+++ b/src/rpp/rpp/schedulers/details/queue_worker_state.hpp
@@ -38,8 +38,8 @@ public:
         return std::tie(m_time_point, m_id) >= std::tie(other.m_time_point, other.m_id);
     }
 
-    time_point GetTimePoint() const { return m_time_point; }
-    SchedulableFn&& ExtractFunction() const { return std::move(m_function); }
+    time_point      get_time_point() const { return m_time_point; }
+    SchedulableFn&& extract_function() const { return std::move(m_function); }
 
 private:
     time_point            m_time_point;
@@ -77,7 +77,7 @@ public:
         if (!is_any_ready_schedulable_unsafe())
             return false;
 
-        out = std::move(m_queue.top().ExtractFunction());
+        out = std::move(m_queue.top().extract_function());
         m_queue.pop();
         return true;
     }
@@ -93,11 +93,11 @@ public:
 
             if (!m_cv.wait_until(lock,
                                  token,
-                                 m_queue.top().GetTimePoint(),
+                                 m_queue.top().get_time_point(),
                                  std::bind_front(&queue_worker_state<SchedulableFn>::is_any_ready_schedulable_unsafe, this)))
                 continue;
 
-            out = std::move(m_queue.top().ExtractFunction());
+            out = std::move(m_queue.top().extract_function());
             m_queue.pop();
             return true;
         }
@@ -119,7 +119,7 @@ private:
 
     bool is_any_ready_schedulable_unsafe() const
     {
-        return !m_queue.empty() && m_queue.top().GetTimePoint() <= clock_type::now();
+        return !m_queue.empty() && m_queue.top().get_time_point() <= clock_type::now();
     }
 
 private:

--- a/src/rpp/rpp/schedulers/details/worker.hpp
+++ b/src/rpp/rpp/schedulers/details/worker.hpp
@@ -14,6 +14,8 @@
 #include <rpp/schedulers/fwd.hpp>         // own forwarding
 #include <rpp/utils/constraints.hpp>
 
+#include <algorithm>
+
 namespace rpp::schedulers
 {
 template<typename T>

--- a/src/rpp/rpp/schedulers/details/worker.hpp
+++ b/src/rpp/rpp/schedulers/details/worker.hpp
@@ -70,13 +70,9 @@ private:
         {
             if (auto duration = m_fn())
             {
-                if (duration.value() != rpp::schedulers::duration::zero())
-                    m_time_point += duration.value();
-                else
-                    m_time_point = m_strategy.now();
+                m_time_point = std::max(m_strategy.now(), m_time_point + duration.value());
 
-                auto time_to_schedule = m_time_point;
-                m_strategy.defer_at(time_to_schedule, std::move(*this));
+                m_strategy.defer_at(m_time_point, std::move(*this));
             }
         }
 

--- a/src/rpp/rpp/schedulers/details/worker.hpp
+++ b/src/rpp/rpp/schedulers/details/worker.hpp
@@ -21,8 +21,39 @@ namespace rpp::schedulers
 template<typename T>
 concept worker_strategy = std::copyable<T> && requires(const T t)
 {
-    t.defer_at(time_point{}, std::declval<void(*)()>());
+    //t.defer_at(time_point{}, std::declval<void(*)()>());
     { t.now() } -> std::same_as<time_point>;
+};
+
+template<constraint::schedulable_fn Fn, worker_strategy Strategy>
+struct schedulable_wrapper
+{
+    schedulable_wrapper(const Strategy& strategy, time_point time_point, const Fn& fn)
+        : m_strategy{ strategy }
+        , m_time_point{ time_point }
+        , m_fn{ fn } {}
+
+    schedulable_wrapper(const Strategy& strategy, time_point time_point, Fn&& fn)
+        : m_strategy{ strategy }
+        , m_time_point{ time_point }
+        , m_fn{ std::move(fn) } {}
+
+    schedulable_wrapper(const schedulable_wrapper&) = default; // LCOV_EXCL_LINE
+    schedulable_wrapper(schedulable_wrapper&&) noexcept(std::is_nothrow_move_constructible_v<Fn>) = default;
+
+    void operator()()
+    {
+        if (auto duration = m_fn())
+        {
+            m_time_point = std::max(m_strategy.now(), m_time_point + duration.value());
+
+            m_strategy.defer_at(m_time_point, std::move(*this));
+        }
+    }
+
+    Strategy   m_strategy;
+    time_point m_time_point;
+    Fn         m_fn{};
 };
 
 template<worker_strategy Strategy>
@@ -48,40 +79,9 @@ public:
 
     void schedule(time_point time_point, constraint::schedulable_fn auto&& fn) const
     {
-        m_strategy.defer_at(time_point, schedulable_wrapper<std::decay_t<decltype(fn)>>{m_strategy, time_point, std::forward<decltype(fn)>(fn)});
+        m_strategy.defer_at(time_point, std::forward<decltype(fn)>(fn));
     }
 
-private:
-    template<constraint::schedulable_fn Fn>
-    struct schedulable_wrapper
-    {
-        schedulable_wrapper(const Strategy& strategy, time_point time_point, const Fn& fn)
-            : m_strategy{strategy}
-            , m_time_point{time_point}
-            , m_fn{fn} {}
-
-        schedulable_wrapper(const Strategy& strategy, time_point time_point, Fn&& fn)
-            : m_strategy{strategy}
-            , m_time_point{time_point}
-            , m_fn{std::move(fn)} {}
-
-        schedulable_wrapper(const schedulable_wrapper&)                                               = default; // LCOV_EXCL_LINE
-        schedulable_wrapper(schedulable_wrapper&&) noexcept(std::is_nothrow_move_constructible_v<Fn>) = default;
-
-        void operator()()
-        {
-            if (auto duration = m_fn())
-            {
-                m_time_point = std::max(m_strategy.now(), m_time_point + duration.value());
-
-                m_strategy.defer_at(m_time_point, std::move(*this));
-            }
-        }
-
-        Strategy   m_strategy;
-        time_point m_time_point;
-        Fn         m_fn{};
-    };
 private:
     Strategy m_strategy;
 };

--- a/src/rpp/rpp/schedulers/fwd.hpp
+++ b/src/rpp/rpp/schedulers/fwd.hpp
@@ -28,6 +28,8 @@ using optional_duration = std::optional<duration>;
 
 class immediate;
 class trampoline;
+using current_thread = trampoline;
+
 class new_thread;
 class run_loop;
 } // namespace rpp::schedulers

--- a/src/rpp/rpp/schedulers/immediate_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/immediate_scheduler.hpp
@@ -27,7 +27,7 @@ namespace rpp::schedulers
 class immediate final : public details::scheduler_tag
 {
 public:
-    class worker
+    class worker : public details::worker_tag
     {
     public:
         worker(const rpp::subscription_base& sub)

--- a/src/rpp/rpp/schedulers/immediate_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/immediate_scheduler.hpp
@@ -27,23 +27,13 @@ namespace rpp::schedulers
 class immediate final : public details::scheduler_tag
 {
 public:
-    class worker : public details::worker_tag
+    class worker_strategy
     {
     public:
-        worker(const rpp::subscription_base& sub)
+        worker_strategy(const rpp::subscription_base& sub)
             : m_sub{sub} {}
 
-        void schedule(constraint::schedulable_fn auto&& fn) const
-        {
-            schedule(now(), std::forward<decltype(fn)>(fn));
-        }
-
-        void schedule(duration delay, constraint::schedulable_fn auto&& fn) const
-        {
-            schedule(now() + delay, std::forward<decltype(fn)>(fn));
-        }
-
-        void schedule(time_point time_point, constraint::schedulable_fn auto&& fn) const
+        void defer_at(time_point time_point, constraint::schedulable_fn auto&& fn) const
         {
             while (m_sub.is_subscribed())
             {
@@ -59,16 +49,15 @@ public:
             }
         }
 
-    private:
         static time_point now() { return clock_type::now();  }
 
     private:
         rpp::subscription_base m_sub;
     };
 
-    static worker create_worker(const rpp::subscription_base& sub = {})
+    static auto create_worker(const rpp::subscription_base& sub = {})
     {
-        return worker{sub};
+        return worker<worker_strategy>{sub};
     }
 };
 } // namespace rpp::schedulers

--- a/src/rpp/rpp/schedulers/new_thread_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/new_thread_scheduler.hpp
@@ -40,7 +40,7 @@ public:
             m_state->init_thread(sub);
         }
 
-        void defer_at(time_point time_point, std::invocable auto&& fn) const
+        void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn) const
         {
             m_state->defer_at(time_point, std::forward<decltype(fn)>(fn));
         }
@@ -55,7 +55,7 @@ public:
             state(const state&) = delete;
             state(state&&) noexcept = delete;
 
-            void defer_at(time_point time_point, std::invocable auto&& fn)
+            void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn)
             {
                 if (m_sub->is_subscribed())
                     m_queue.emplace(time_point, std::forward<decltype(fn)>(fn));

--- a/src/rpp/rpp/schedulers/new_thread_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/new_thread_scheduler.hpp
@@ -44,7 +44,7 @@ public:
 
         void defer_at(time_point time_point, constraint::schedulable_fn auto&& fn) const
         {
-            defer_at(time_point, schedulable_wrapper{*this, time_point, std::forward<decltype(fn)>(fn)});
+            defer_at(time_point, new_thread_schedulable{*this, time_point, std::forward<decltype(fn)>(fn)});
         }
 
         void defer_at(time_point time_point, new_thread_schedulable&& fn) const
@@ -62,10 +62,10 @@ public:
             state(const state&) = delete;
             state(state&&) noexcept = delete;
 
-            void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn)
+            void defer_at(time_point time_point, new_thread_schedulable&& fn)
             {
                 if (m_sub->is_subscribed())
-                    m_queue.emplace(time_point, std::forward<decltype(fn)>(fn));
+                    m_queue.emplace(time_point, std::move(fn));
             }
 
             void init_thread(const rpp::composite_subscription& sub)

--- a/src/rpp/rpp/schedulers/new_thread_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/new_thread_scheduler.hpp
@@ -40,9 +40,15 @@ public:
             m_state->init_thread(sub);
         }
 
-        void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn) const
+        void defer_at(time_point time_point, constraint::schedulable_fn auto&& fn) const
         {
-            m_state->defer_at(time_point, std::forward<decltype(fn)>(fn));
+            defer_at(time_point, schedulable_wrapper{*this, time_point, std::forward<decltype(fn)>(fn)});
+        }
+
+        template<typename Fn, typename Strategy>
+        void defer_at(time_point time_point, schedulable_wrapper<Fn, Strategy>&& fn) const
+        {
+            m_state->defer_at(time_point, std::move(fn));
         }
 
         static time_point now() { return clock_type::now(); }

--- a/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
@@ -63,7 +63,13 @@ public:
             : m_queue{queue}
             , m_sub{sub} { }
 
-        void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn) const
+        void defer_at(time_point time_point, constraint::schedulable_fn auto&& fn) const
+        {
+            defer_at(time_point, schedulable_wrapper{ *this, time_point, std::forward<decltype(fn)>(fn) });
+        }
+
+        template<typename Fn, typename Strategy>
+        void defer_at(time_point time_point, schedulable_wrapper<Fn, Strategy>&& fn) const
         {
             if (m_sub.is_subscribed())
                 m_queue->emplace(time_point, std::forward<decltype(fn)>(fn));

--- a/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
@@ -42,11 +42,10 @@ private:
 
         void defer_at(time_point time_point, constraint::schedulable_fn auto&& fn) const
         {
-            defer_at(time_point, schedulable_wrapper{*this, time_point, std::forward<decltype(fn)>(fn)});
+            defer_at(time_point, run_loop_schedulable{*this, time_point, std::forward<decltype(fn)>(fn)});
         }
 
-        template<typename Strategy>
-        void defer_at(time_point time_point, schedulable_wrapper<Strategy>&& fn) const
+        void defer_at(time_point time_point, run_loop_schedulable&& fn) const
         {
             if (m_sub.is_subscribed())
                 m_queue->emplace(time_point, std::move(fn));

--- a/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
@@ -63,7 +63,7 @@ public:
             : m_queue{queue}
             , m_sub{sub} { }
 
-        void defer_at(time_point time_point, std::invocable auto&& fn) const
+        void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn) const
         {
             if (m_sub.is_subscribed())
                 m_queue->emplace(time_point, std::forward<decltype(fn)>(fn));

--- a/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
@@ -29,47 +29,24 @@ namespace rpp::schedulers
 class run_loop final : public details::scheduler_tag
 {
 private:
-    class state
-    {
-    public:
-        state(const composite_subscription& sub = composite_subscription{})
-            : m_sub{sub} { }
+    class worker_strategy;
+    using run_loop_schedulable = schedulable_wrapper<worker_strategy>;
 
-        state(const state&) = delete;
-        state(state&&) noexcept = delete;
-
-        ~state()
-        {
-            m_source.request_stop();
-            m_sub.unsubscribe();
-        }
-
-        details::queue_worker_state& get_queue() { return m_queue; }
-        std::stop_token              get_token() const { return m_source.get_token(); }
-
-        composite_subscription& get_subscription() { return m_sub; }
-    private:
-        rpp::composite_subscription m_sub;
-        details::queue_worker_state m_queue{};
-        std::stop_source            m_source{};
-    };
-
-public:
     class worker_strategy
     {
     public:
-        worker_strategy(const std::shared_ptr<details::queue_worker_state>& queue,
-                        const composite_subscription&                       sub)
+        worker_strategy(const std::shared_ptr<details::queue_worker_state<run_loop_schedulable>>& queue,
+                        const composite_subscription&                                             sub)
             : m_queue{queue}
             , m_sub{sub} { }
 
         void defer_at(time_point time_point, constraint::schedulable_fn auto&& fn) const
         {
-            defer_at(time_point, schedulable_wrapper{ *this, time_point, std::forward<decltype(fn)>(fn) });
+            defer_at(time_point, schedulable_wrapper{*this, time_point, std::forward<decltype(fn)>(fn)});
         }
 
-        template<typename Fn, typename Strategy>
-        void defer_at(time_point time_point, schedulable_wrapper<Fn, Strategy>&& fn) const
+        template<typename Strategy>
+        void defer_at(time_point time_point, schedulable_wrapper<Strategy>&& fn) const
         {
             if (m_sub.is_subscribed())
                 m_queue->emplace(time_point, std::move(fn));
@@ -78,9 +55,37 @@ public:
         static time_point now() { return clock_type::now(); }
 
     private:
-        std::shared_ptr<details::queue_worker_state> m_queue{};
-        composite_subscription                       m_sub{};
+        std::shared_ptr<details::queue_worker_state<run_loop_schedulable>> m_queue{};
+        composite_subscription                                             m_sub{};
     };
+
+    class state
+    {
+    public:
+        state(const composite_subscription& sub = composite_subscription{})
+            : m_sub{sub} { }
+
+        state(const state&)     = delete;
+        state(state&&) noexcept = delete;
+
+        ~state()
+        {
+            m_source.request_stop();
+            m_sub.unsubscribe();
+        }
+
+        details::queue_worker_state<run_loop_schedulable>& get_queue() { return m_queue; }
+        std::stop_token                                    get_token() const { return m_source.get_token(); }
+
+        composite_subscription& get_subscription() { return m_sub; }
+    private:
+        rpp::composite_subscription                       m_sub;
+        details::queue_worker_state<run_loop_schedulable> m_queue{};
+        std::stop_source                                  m_source{};
+    };
+
+public:
+
 
     run_loop(const composite_subscription& sub = composite_subscription{})
         : m_state(std::make_shared<state>(sub)) {}
@@ -93,7 +98,7 @@ public:
             if (const auto sh = weak.lock())
                 sh->get_subscription().remove(res);
         });
-        return worker<worker_strategy>{std::shared_ptr<details::queue_worker_state>{m_state, &m_state->get_queue()}, sub};
+        return worker<worker_strategy>{std::shared_ptr<details::queue_worker_state<run_loop_schedulable>>{m_state, &m_state->get_queue()}, sub};
     }
 
     bool is_empty() const
@@ -108,16 +113,16 @@ public:
 
     void dispatch_if_ready() const
     {
-        std::function<void()> fn{};
+        std::optional<run_loop_schedulable> fn{};
         if (m_state->get_queue().pop_if_ready(fn))
-            fn();
+            (*fn)();
     }
 
     void dispatch() const
     {
-        std::function<void()> fn{};
+        std::optional<run_loop_schedulable> fn{};
         if (m_state->get_queue().pop_with_wait(fn, m_state->get_token()))
-            fn();
+            (*fn)();
     }
 
 private:

--- a/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/run_loop_scheduler.hpp
@@ -72,7 +72,7 @@ public:
         void defer_at(time_point time_point, schedulable_wrapper<Fn, Strategy>&& fn) const
         {
             if (m_sub.is_subscribed())
-                m_queue->emplace(time_point, std::forward<decltype(fn)>(fn));
+                m_queue->emplace(time_point, std::move(fn));
         }
 
         static time_point now() { return clock_type::now(); }

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -106,13 +106,37 @@ public:
         explicit worker_strategy(const rpp::composite_subscription& subscription)
             : m_sub{subscription} {}
 
-        void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn) const
+        void defer_at(time_point time_point, constraint::schedulable_fn auto&& fn) const
         {
             if (!m_sub.is_subscribed())
                 return;
 
             auto drain_handle = ensure_queue_if_no_any_owner();
-            get_schedulable_queue()->emplace(time_point, std::forward<decltype(fn)>(fn), m_sub);
+
+            // do immediate scheduling till queue is empty
+            while (m_sub.is_subscribed() && get_schedulable_queue()->empty())
+            {
+                std::this_thread::sleep_until(time_point);
+
+                if (!m_sub.is_subscribed())
+                    return;
+
+                if (const auto duration = fn())
+                    time_point = std::max(now(), time_point + duration.value());
+                else
+                    return;
+            }
+
+            defer_at(time_point, schedulable_wrapper{ *this, time_point, std::forward<decltype(fn)>(fn) });
+        }
+
+        template<typename Fn, typename Strategy>
+        void defer_at(time_point time_point, schedulable_wrapper<Fn, Strategy>&& fn) const
+        {
+            if (!m_sub.is_subscribed())
+                return;
+
+            get_schedulable_queue()->emplace(time_point, std::move(fn), m_sub);
         }
 
         static time_point now() { return clock_type::now(); }

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -36,55 +36,95 @@ namespace rpp::schedulers
  */
 class trampoline final : public details::scheduler_tag
 {
+    class current_thread_schedulable : public details::schedulable
+    {
+    public:
+        current_thread_schedulable(time_point                  time_point,
+            std::invocable auto&& fn,
+            rpp::composite_subscription subscription)
+            : schedulable(time_point, get_thread_local_id(), std::forward<decltype(fn)>(fn))
+            , m_subscription{ std::move(subscription) } {}
+
+        bool is_subscribed() const { return m_subscription.is_subscribed(); }
+
+    private:
+        static size_t get_thread_local_id()
+        {
+            static thread_local size_t s_id;
+            return s_id++;
+        }
+
+    private:
+        rpp::composite_subscription m_subscription{};
+    };
+
+    /**
+     * \brief Returns optional thread_local schedulable queue. If optional has value -> someone just owns thread.
+     */
+    static std::optional<std::priority_queue<current_thread_schedulable>>& get_schedulable_queue()
+    {
+        static thread_local std::optional<std::priority_queue<current_thread_schedulable>> s_queue{};
+        return s_queue;
+    }
+
 public:
     class worker_strategy
     {
     public:
         explicit worker_strategy(const rpp::composite_subscription& subscription)
-            : m_sub{subscription} {};
+            : m_sub{subscription} {}
 
         void defer_at(time_point time_point, std::invocable auto&& fn) const
         {
             if (!m_sub.is_subscribed())
                 return;
 
-            with_thread_local_schedulable_queue([&](auto& queue, bool& queue_in_use)
-            {
-                queue.emplace(time_point, std::forward<decltype(fn)>(fn));
+            auto&      queue              = get_schedulable_queue();
+            const bool someone_owns_queue = queue.has_value();
+            if (!someone_owns_queue)
+                queue = std::priority_queue<current_thread_schedulable>{};
 
-                if (queue_in_use)
-                    return;
+            queue->emplace(time_point, std::forward<decltype(fn)>(fn), m_sub);
 
-                queue_in_use = true;
-                utils::finally_action cleanup([&]() noexcept
-                {
-                    // If error occurs, we still want the thread-local state to be reset.
-                    queue_in_use = false;
-                    if (!m_sub.is_subscribed())
-                        queue.reset();
-                });
-
-                std::stop_source stop;
-                auto stop_token = stop.get_token();
-                m_sub.add([stop = std::move(stop)]() mutable
-                {
-                    // The following blocking-pop exits when subscription is unsubscribed in other thread.
-                    stop.request_stop();
-                });
-
-                while (!queue.is_empty() && m_sub.is_subscribed())
-                {
-                    std::function<void()> schedulable{};
-                    if (queue.pop_with_wait(schedulable, stop_token))
-                    {
-                        schedulable();
-                        schedulable = {};
-                    }
-                }
-            });
+            if (!someone_owns_queue)
+                process_queue();
         }
 
         static time_point now() { return clock_type::now(); }
+
+    private:
+        void process_queue() const
+        {
+            auto& queue = get_schedulable_queue();
+
+            while (!queue->empty())
+            {
+                const auto& top = queue->top();
+
+                auto function  = wait_and_extract_executable_from_schedulable_if_subscribed(top);
+
+                // firstly we need to pop schedulable from queue due to exectuion of function can add new schedulable
+                queue->pop();
+
+                if (function)
+                    function();
+            }
+
+            queue.reset();
+        }
+
+        [[nodiscard]] std::function<void()> wait_and_extract_executable_from_schedulable_if_subscribed(const  current_thread_schedulable& schedulable) const
+        {
+            if (!schedulable.is_subscribed())
+                return {};
+
+            std::this_thread::sleep_until(schedulable.GetTimePoint());
+
+            if (!schedulable.is_subscribed())
+                return {};
+
+            return std::move(schedulable.ExtractFunction());
+        }
 
     private:
         rpp::composite_subscription m_sub;
@@ -93,19 +133,6 @@ public:
     static auto create_worker(const rpp::composite_subscription& sub = composite_subscription{})
     {
         return worker<worker_strategy>{sub};
-    }
-
-private:
-    /**
-     * \brief evaluates given lambda with the thread local queue and ownership-flag.
-     *
-     * \param action a lambda that is given with the thread local queue and ownership-flag.
-     */
-    static void with_thread_local_schedulable_queue(std::function<void(rpp::schedulers::details::queue_worker_state&, bool&)>&& action)
-    {
-        static thread_local rpp::schedulers::details::queue_worker_state queue{};
-        static thread_local bool queue_in_use{false};
-        action(queue, queue_in_use);
     }
 };
 } // namespace rpp::schedulers

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -11,12 +11,12 @@
 
 #pragma once
 
-#include "rpp/utils/utilities.hpp"
 
 #include <rpp/schedulers/fwd.hpp>                       // own forwarding
 #include <rpp/schedulers/details/worker.hpp>            // worker
 #include <rpp/subscriptions/composite_subscription.hpp> // lifetime
 #include <rpp/schedulers/details/queue_worker_state.hpp>// state
+#include <rpp/utils/utilities.hpp>
 
 #include <concepts>
 #include <chrono>

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -147,12 +147,12 @@ class trampoline final : public details::scheduler_tag
         if (!schedulable.is_subscribed())
             return {};
 
-        std::this_thread::sleep_until(schedulable.GetTimePoint());
+        std::this_thread::sleep_until(schedulable.get_time_point());
 
         if (!schedulable.is_subscribed())
             return {};
 
-        return std::move(schedulable.ExtractFunction());
+        return std::move(schedulable.extract_function());
     }
 
 public:

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -69,7 +69,8 @@ class trampoline final : public details::scheduler_tag
 
     static void drain_queue()
     {
-        auto& queue = get_schedulable_queue();
+        auto& queue          = get_schedulable_queue();
+        auto  reset_at_final = utils::finally_action{[] { get_schedulable_queue().reset(); }};
 
         while (!queue->empty())
         {
@@ -83,8 +84,6 @@ class trampoline final : public details::scheduler_tag
             if (function)
                 function();
         }
-
-        queue.reset();
     }
 
     [[nodiscard]] static std::function<void()> wait_and_extract_executable_if_subscribed(const  current_thread_schedulable& schedulable)

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -157,18 +157,7 @@ public:
         rpp::composite_subscription m_sub;
     };
 
-    /**
-     * \brief Take ownership over queue and return handle which would drain queue during destruction
-     */
-    [[nodiscard]] static utils::finally_action<void(*)()> ensure_queue_if_no_any_owner()
-    {
-        auto& queue = get_schedulable_queue();
-        if (queue.has_value())
-            return utils::finally_action{+[] {}};
-
-        queue = std::priority_queue<current_thread_schedulable>{};
-        return utils::finally_action{&drain_queue};
-    }
+    static bool is_queue_owned() { return get_schedulable_queue().has_value(); }
 
     static auto create_worker(const rpp::composite_subscription& sub = composite_subscription{})
     {

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -106,7 +106,7 @@ public:
         explicit worker_strategy(const rpp::composite_subscription& subscription)
             : m_sub{subscription} {}
 
-        void defer_at(time_point time_point, std::invocable auto&& fn) const
+        void defer_at(time_point time_point, constraint::inner_schedulable_fn auto&& fn) const
         {
             if (!m_sub.is_subscribed())
                 return;

--- a/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
+++ b/src/rpp/rpp/schedulers/trampoline_scheduler.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "rpp/utils/utilities.hpp"
+
 #include <rpp/schedulers/fwd.hpp>                       // own forwarding
 #include <rpp/schedulers/details/worker.hpp>            // worker
 #include <rpp/subscriptions/composite_subscription.hpp> // lifetime
@@ -24,14 +26,6 @@
 
 namespace rpp::schedulers
 {
-
-template <typename F>
-struct scope_guard {
-    explicit scope_guard(F&& f) : m_f(std::move(f)) {}
-    ~scope_guard() noexcept { m_f(); }
-    F m_f;
-};
-
 /**
  * \brief schedules execution of schedulables via queueing tasks to the caller thread with priority to time_point and order
  *
@@ -62,7 +56,7 @@ public:
                     return;
 
                 queue_in_use = true;
-                scope_guard cleanup([&]() noexcept
+                utils::finally_action cleanup([&]() noexcept
                 {
                     // If error occurs, we still want the thread-local state to be reset.
                     queue_in_use = false;

--- a/src/rpp/rpp/utils/utilities.hpp
+++ b/src/rpp/rpp/utils/utilities.hpp
@@ -85,4 +85,25 @@ public:
 private:
     RPP_NO_UNIQUE_ADDRESS std::optional<Callable> m_callable;
 };
+
+/**
+ * \brief Calls passed function during destruction
+ */
+template<std::invocable Fn>
+class finally_action
+{
+public:
+    finally_action(Fn&& fn)
+        : m_fn{std::move(fn)} {}
+
+    finally_action(const Fn& fn)
+        : m_fn{fn} {}
+
+    ~finally_action() noexcept
+    {
+        m_fn();
+    }
+private:
+    Fn m_fn;
+};
 } // namespace rpp::utils

--- a/src/samples/doxygen/trampoline.cpp
+++ b/src/samples/doxygen/trampoline.cpp
@@ -14,12 +14,9 @@ int main()
 {
     //! [trampoline]
     rpp::source::just(rpp::schedulers::trampoline{}, 1, 2, 3)
-        .merge_with(rpp::source::just(rpp::schedulers::trampoline{}, 4, 5, 6))
-        .subscribe_on(rpp::schedulers::trampoline{})
-        .subscribe(
-            [](const int &v) { std::cout << "-" << v; },
-            [](const std::exception_ptr &error) {},
-            []() { std::cout << "-|" << std::endl; });
+            .merge_with(rpp::source::just(rpp::schedulers::trampoline{}, 4, 5, 6))
+            .subscribe([](const int& v) { std::cout << "-" << v; },
+                       []() { std::cout << "-|" << std::endl; });
     // Source 1: -1-2-3-|
     // Source 2:        -4-5-6-|
     // Output  : -1-4-2-5-3-6-|

--- a/src/tests/benchmarks.cpp
+++ b/src/tests/benchmarks.cpp
@@ -870,4 +870,22 @@ TEST_CASE("trampoline scheduler")
             worker.schedule(time, work);
         });
     };
+
+    BENCHMARK_ADVANCED("recursively schedule 10 times")(Catch::Benchmark::Chronometer meter)
+    {
+        rpp::schedulers::trampoline scheduler{};
+        auto                        worker = scheduler.create_worker();
+        auto                        time   = rpp::schedulers::clock_type::now();
+
+        auto work = [&]()
+        {
+            for (size_t i = 0; i < 10; ++i)
+                worker.schedule(time, []() { return rpp::schedulers::optional_duration{}; });
+            return rpp::schedulers::optional_duration{};
+        };
+        meter.measure([&]
+        {
+            worker.schedule(time, work);
+        });
+    };
 }

--- a/src/tests/rxcpp_benchmark.cpp
+++ b/src/tests/rxcpp_benchmark.cpp
@@ -865,5 +865,22 @@ TEST_CASE("trampoline scheduler")
             worker.schedule(time, work);
         });
     };
+
+    BENCHMARK_ADVANCED("recursively schedule 10 times")(Catch::Benchmark::Chronometer meter)
+    {
+        auto scheduler = rxcpp::schedulers::make_current_thread();
+        auto worker    = scheduler.create_worker();
+        auto time      = scheduler.now();
+
+        auto work = [&](const rxcpp::schedulers::schedulable&)
+        {
+            for (size_t i = 0; i < 10; ++i)
+                worker.schedule(time, [](const rxcpp::schedulers::schedulable&) { });
+        };
+        meter.measure([&]
+        {
+            worker.schedule(time, work);
+        });
+    };
 }
 

--- a/src/tests/test_observe_on.cpp
+++ b/src/tests/test_observe_on.cpp
@@ -83,7 +83,7 @@ SCENARIO("observe_on transfers emssions to scheduler", "[operators][observe_on]"
     }
 }
 
-SCENARIO("observe_on doesn't produce a lot of copies", "[operators][observe_on][track_copy]")
+SCENARIO("observe_on with immediate doesn't produce a lot of copies", "[operators][observe_on][track_copy]")
 {
     GIVEN("observable with value by copy")
     {
@@ -91,10 +91,10 @@ SCENARIO("observe_on doesn't produce a lot of copies", "[operators][observe_on][
         WHEN("subscribe on it via scheduler")
         {
             tracker.get_observable().observe_on(rpp::schedulers::immediate{}).subscribe();
-            THEN("only 1 extra copy and 1 move")
+            THEN("only 1 extra copy")
             {
                 CHECK(tracker.get_copy_count() == 1);
-                CHECK(tracker.get_move_count() == 1);
+                CHECK(tracker.get_move_count() == 0);
             }
         }
     }
@@ -104,10 +104,10 @@ SCENARIO("observe_on doesn't produce a lot of copies", "[operators][observe_on][
         WHEN("subscribe on it via scheduler")
         {
             tracker.get_observable_for_move().observe_on(rpp::schedulers::immediate{}).subscribe();
-            THEN("only 2 extra moves")
+            THEN("only 1 extra move")
             {
                 CHECK(tracker.get_copy_count() == 0);
-                CHECK(tracker.get_move_count() == 2);
+                CHECK(tracker.get_move_count() == 1);
             }
         }
     }

--- a/src/tests/test_scheduler.hpp
+++ b/src/tests/test_scheduler.hpp
@@ -24,7 +24,7 @@ public:
             : m_sub{ sub }
             , m_schedulings{ schedulings } {}
 
-        void defer_at(rpp::schedulers::time_point time_point, std::invocable auto&& fn) const
+        void defer_at(rpp::schedulers::time_point time_point, rpp::schedulers::constraint::inner_schedulable_fn auto&& fn) const
         {
             if (m_sub.is_subscribed())
             {

--- a/src/tests/test_scheduler.hpp
+++ b/src/tests/test_scheduler.hpp
@@ -24,12 +24,16 @@ public:
             : m_sub{ sub }
             , m_schedulings{ schedulings } {}
 
-        void defer_at(rpp::schedulers::time_point time_point, rpp::schedulers::constraint::inner_schedulable_fn auto&& fn) const
+        void defer_at(rpp::schedulers::time_point time_point, rpp::schedulers::constraint::schedulable_fn auto&& fn) const
         {
-            if (m_sub.is_subscribed())
+            while (m_sub.is_subscribed())
             {
                 m_schedulings->push_back(time_point);
-                fn();
+
+                if (auto duration = fn())
+                    time_point = std::max(now(), time_point + duration.value());
+                else
+                    return;
             }
         }
 

--- a/src/tests/test_schedulers.cpp
+++ b/src/tests/test_schedulers.cpp
@@ -18,6 +18,7 @@
 #include <rpp/schedulers/run_loop_scheduler.hpp>
 
 #include <future>
+#include <sstream>
 
 using namespace std::string_literals;
 


### PR DESCRIPTION
## Changes:
- refactor code to make it faster and more structural
- speedup trampoline scheduler
- use it inside specific_observable to take ownership over queue
- get rid of recursion in immediate scheduler


[WIP]:
- need to improve performance via elimination of copy of std::function
- need to improve performance via using "immediate-like" scheduling till it is only one schedulable
- make wait stoppable