### PR TITLE
Use spinlock in "partly-multithreaded" operators instead of heavy-mutex

### DIFF
--- a/src/rpp/rpp/operators/combine_latest.hpp
+++ b/src/rpp/rpp/operators/combine_latest.hpp
@@ -75,7 +75,7 @@ struct combine_latest_state_with_serialized_spinlock : combine_latest_state<TCom
 {
     using combine_latest_state<TCombiner,Types...>::combine_latest_state;
 
-    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (due to values_mutex), but we have small probability to get error from another thread immediately
+    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next serialized (due to values_mutex), but we have small probability to get error from another observable immediately
     utils::spinlock spinlock{};
 };
 

--- a/src/rpp/rpp/operators/concat.hpp
+++ b/src/rpp/rpp/operators/concat.hpp
@@ -120,7 +120,7 @@ struct concat_state_with_serialized_spinlock : concat_state<ValueType>
 {
     using concat_state<ValueType>::concat_state;
 
-    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (only one active observable), but we have small probability to get error from main thread immediately
+    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (only one active observable), but we have small probability to get error from main observable immediately
     utils::spinlock spinlock{};
 };
 

--- a/src/rpp/rpp/operators/concat.hpp
+++ b/src/rpp/rpp/operators/concat.hpp
@@ -20,6 +20,8 @@
 
 #include <rpp/sources/just.hpp>
 #include <rpp/utils/functors.hpp>
+#include <rpp/utils/spinlock.hpp>
+
 
 #include <mutex>
 #include <memory>
@@ -114,11 +116,12 @@ struct concat_on_completed
 
 
 template<constraint::decayed_type ValueType>
-struct concat_state_with_serialized_mutex : concat_state<ValueType>
+struct concat_state_with_serialized_spinlock : concat_state<ValueType>
 {
     using concat_state<ValueType>::concat_state;
 
-    std::mutex mutex{};
+    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (only one active observable), but we have small probability to get error from main thread immediately
+    utils::spinlock spinlock{};
 };
 
 template<constraint::decayed_type Type>
@@ -129,10 +132,10 @@ struct concat_impl
     template<constraint::subscriber_of_type<ValueType> TSub>
     auto operator()(TSub&& in_subscriber) const
     {
-        auto state = std::make_shared<concat_state_with_serialized_mutex<ValueType>>(in_subscriber.get_subscription());
+        auto state = std::make_shared<concat_state_with_serialized_spinlock<ValueType>>(in_subscriber.get_subscription());
 
         // change subscriber to serialized to avoid manual using of mutex
-        auto subscriber = make_serialized_subscriber(std::forward<TSub>(in_subscriber), std::shared_ptr<std::mutex>{state, &state->mutex});
+        auto subscriber = make_serialized_subscriber(std::forward<TSub>(in_subscriber), std::shared_ptr<utils::spinlock>{state, &state->spinlock});
 
         return create_subscriber_with_state<Type>(state->source_subscription,
                                                   concat_on_next_outer<ValueType>{},

--- a/src/rpp/rpp/operators/switch_on_next.hpp
+++ b/src/rpp/rpp/operators/switch_on_next.hpp
@@ -81,7 +81,7 @@ struct switch_on_next_state_with_serialized_spinlock : switch_on_next_state
 {
     using switch_on_next_state::switch_on_next_state;
 
-    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (only one active observable), but we have small probability to get error from main thread immediately
+    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (only one active observable), but we have small probability to get error from main observable immediately
     utils::spinlock spinlock{};
 };
 

--- a/src/rpp/rpp/operators/with_latest_from.hpp
+++ b/src/rpp/rpp/operators/with_latest_from.hpp
@@ -20,6 +20,7 @@
 #include <rpp/subscribers/constraints.hpp>
 #include <rpp/utils/utilities.hpp>
 #include <rpp/utils/functors.hpp>
+#include <rpp/utils/spinlock.hpp>
 
 #include <mutex>
 #include <array>
@@ -105,11 +106,12 @@ struct with_latest_from_on_next_outer
 };
 
 template<typename TSelector, constraint::decayed_type... ValueTypes>
-struct with_latest_from_state_with_serialized_mutex : public with_latest_from_state<TSelector, ValueTypes...>
+struct with_latest_from_state_with_serialized_spinlock : public with_latest_from_state<TSelector, ValueTypes...>
 {
     using with_latest_from_state<TSelector, ValueTypes...>::with_latest_from_state;
 
-    std::mutex mutex{};
+    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (root observable), but we have small probability to get error from inner observables immediately
+    utils::spinlock spinlock{};
 };
 
 template<constraint::decayed_type Type, typename TSelector, constraint::observable ...TObservables>
@@ -124,9 +126,9 @@ struct with_latest_from_impl
     template<constraint::subscriber_of_type<ResultType> TSub>
     auto operator()(TSub&& in_subscriber) const
     {
-        auto state = std::make_shared<with_latest_from_state_with_serialized_mutex<TSelector, utils::extract_observable_type_t<TObservables>...>>(selector, in_subscriber.get_subscription());
+        auto state = std::make_shared<with_latest_from_state_with_serialized_spinlock<TSelector, utils::extract_observable_type_t<TObservables>...>>(selector, in_subscriber.get_subscription());
         // change subscriber to serialized to avoid manual using of mutex
-        auto subscriber = make_serialized_subscriber(std::forward<TSub>(in_subscriber), std::shared_ptr<std::mutex>{state, &state->mutex});
+        auto subscriber = make_serialized_subscriber(std::forward<TSub>(in_subscriber), std::shared_ptr<utils::spinlock>{state, &state->spinlock});
 
         with_latest_from_subscribe_observables(std::index_sequence_for<TObservables...>{},
                                                state,

--- a/src/rpp/rpp/operators/with_latest_from.hpp
+++ b/src/rpp/rpp/operators/with_latest_from.hpp
@@ -110,7 +110,7 @@ struct with_latest_from_state_with_serialized_spinlock : public with_latest_from
 {
     using with_latest_from_state<TSelector, ValueTypes...>::with_latest_from_state;
 
-    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (root observable), but we have small probability to get error from inner observables immediately
+    // we can use spinlock there because 99.9% of time only one ever thread would send values from on_next (main observable), but we have small probability to get error from inner observables immediately
     utils::spinlock spinlock{};
 };
 

--- a/src/rpp/rpp/utils/spinlock.hpp
+++ b/src/rpp/rpp/utils/spinlock.hpp
@@ -1,0 +1,36 @@
+//                   ReactivePlusPlus library
+// 
+//           Copyright Aleksey Loginov 2022 - present.
+//  Distributed under the Boost Software License, Version 1.0.
+//     (See accompanying file LICENSE_1_0.txt or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+// 
+//  Project home: https://github.com/victimsnino/ReactivePlusPlus
+
+#pragma once
+#include <atomic>
+
+namespace rpp::utils
+{
+class spinlock
+{
+public:
+    spinlock() { m_lock_flag.clear(); }
+
+    void lock()
+    {
+        while(m_lock_flag.test_and_set(std::memory_order_acquire))
+        {
+            while(m_lock_flag.test(std::memory_order_relaxed)){};
+        }
+    }
+
+    void unlock()
+    {
+        m_lock_flag.clear(std::memory_order_release);
+    }
+
+private:
+    std::atomic_flag m_lock_flag;
+};
+} // namespace rpp::utils

--- a/src/rpp/rpp/utils/spinlock.hpp
+++ b/src/rpp/rpp/utils/spinlock.hpp
@@ -15,22 +15,22 @@ namespace rpp::utils
 class spinlock
 {
 public:
-    spinlock() { m_lock_flag.clear(); }
+    spinlock() = default;
 
     void lock()
     {
-        while(m_lock_flag.test_and_set(std::memory_order_acquire))
+        while(m_lock_flag.exchange(true, std::memory_order_acquire))
         {
-            while(m_lock_flag.test(std::memory_order_relaxed)){};
+            while(m_lock_flag.load(std::memory_order_relaxed)){};
         }
     }
 
     void unlock()
     {
-        m_lock_flag.clear(std::memory_order_release);
+        m_lock_flag.store(false, std::memory_order_release);
     }
 
 private:
-    std::atomic_flag m_lock_flag;
+    std::atomic_bool m_lock_flag{false};
 };
 } // namespace rpp::utils


### PR DESCRIPTION
Resolves #267