### PR TITLE
Make lift more readable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .vs/
 .vscode/
+.cache/
 build/
 _build/
 cmake/open-cpp-coverage.cmake

--- a/src/rpp/rpp/operators/lift.hpp
+++ b/src/rpp/rpp/operators/lift.hpp
@@ -22,23 +22,6 @@ IMPLEMENTATION_FILE(lift_tag);
 
 namespace rpp::details
 {
-template<constraint::decayed_type                 Type,
-         constraint::subscriber                   TSub,
-         std::invocable<Type, TSub>               OnNext,
-         std::invocable<std::exception_ptr, TSub> OnError     = utils::forwarding_on_error,
-         std::invocable<TSub>                     OnCompleted = utils::forwarding_on_completed>
-auto create_subscriber_in_lift(TSub&&        subscriber,
-                               OnNext&&      on_next      = {},
-                               OnError&&     on_error     = {},
-                               OnCompleted&& on_completed = {})
-{
-    auto subscription = subscriber.get_subscription();
-    return create_subscriber_with_state<Type>(std::move(subscription),
-                                              std::forward<OnNext>(on_next),
-                                              std::forward<OnError>(on_error),
-                                              std::forward<OnCompleted>(on_completed),
-                                              std::forward<TSub>(subscriber));
-}
 template<constraint::decayed_type Type, constraint::decayed_type OnNext, constraint::decayed_type OnError, constraint::decayed_type OnCompleted>
 struct lift_action_by_callbacks
 {
@@ -49,7 +32,12 @@ struct lift_action_by_callbacks
     template<constraint::subscriber TSub>
     auto operator()(TSub&& subscriber) const
     {
-        return create_subscriber_in_lift<Type>(std::forward<TSub>(subscriber), on_next, on_error, on_completed);
+        auto subscription = subscriber.get_subscription();
+        return create_subscriber_with_state<Type>(std::move(subscription),
+                                                  on_next,
+                                                  on_error,
+                                                  on_completed,
+                                                  std::forward<TSub>(subscriber));
     }
 };
 

--- a/src/rpp/rpp/operators/map.hpp
+++ b/src/rpp/rpp/operators/map.hpp
@@ -24,7 +24,7 @@ IMPLEMENTATION_FILE(map_tag);
 namespace rpp::details
 {
 template<constraint::decayed_type Type, std::invocable<Type> Callable>
-struct map_impl
+struct map_impl_on_next
 {
     RPP_NO_UNIQUE_ADDRESS Callable callable;
 
@@ -32,6 +32,18 @@ struct map_impl
     void operator()(TVal&& value, const TSub& subscriber) const
     {
         subscriber.on_next(callable(utils::as_const(std::forward<TVal>(value))));
+    }
+};
+
+template<constraint::decayed_type Type, std::invocable<Type> Callable>
+struct map_impl
+{
+    RPP_NO_UNIQUE_ADDRESS map_impl_on_next<Type, Callable> on_next;
+
+    template<constraint::subscriber TSub>
+    auto operator()(TSub&& subscriber) const
+    {
+        return create_subscriber_in_lift<Type>(std::forward<TSub>(subscriber), on_next);
     }
 };
 } // namespace rpp::details

--- a/src/rpp/rpp/operators/map.hpp
+++ b/src/rpp/rpp/operators/map.hpp
@@ -43,7 +43,12 @@ struct map_impl
     template<constraint::subscriber TSub>
     auto operator()(TSub&& subscriber) const
     {
-        return create_subscriber_in_lift<Type>(std::forward<TSub>(subscriber), on_next);
+        auto subscription = subscriber.get_subscription();
+        return create_subscriber_with_state<Type>(std::move(subscription),
+                                                  on_next,
+                                                  utils::forwarding_on_error{},
+                                                  utils::forwarding_on_completed{},
+                                                  std::forward<TSub>(subscriber));
     }
 };
 } // namespace rpp::details


### PR DESCRIPTION
Before:
```
specific_observable<int, 
rpp::details::lift_on_subscribe<int, 

rpp::details::lift_action_by_callbacks<int, rpp::details::map_impl<int, int (*)(int) noexcept>, rpp::utils::forwarding_on_error, rpp::utils::forwarding_on_completed>,
  
rpp::specific_observable<int, 
rpp::details::lift_on_subscribe<int, 

rpp::details::lift_action_by_callbacks<int, rpp::details::filter_impl<int, std::_Not_fn<int (*)(int) noexcept>>, rpp::utils::forwarding_on_error, rpp::utils::forwarding_on_completed>, 

rpp::specific_observable<int, 
rpp::details::lift_on_subscribe<int, 

rpp::details::lift_action_by_callbacks<int, rpp::details::take_while_impl<int, (lambda)>, rpp::utils::forwarding_on_error, rpp::utils::forwarding_on_completed>, 

rpp::specific_observable<int, 
rpp::details::repeat_on_subscribe<int, 

rpp::specific_observable<int, 
rpp::details::lift_on_subscribe<int, 

rpp::details::lift_action_by_callbacks<int (*)(), rpp::details::map_impl<int (*)(), (lambda)>, rpp::utils::forwarding_on_error, rpp::utils::forwarding_on_completed>, 

rpp::specific_observable<int (*)(), rpp::observable::details::iterate_impl<std::array<int (*)(), 1>, rpp::schedulers::trampoline>>>>, (lambda)>>>>>>>>
```

After:
```
specific_observable<int, 
rpp::details::lift_on_subscribe<int, 

rpp::details::map_impl<int, int (*)(int) noexcept>, 

rpp::details::filter_impl<int, std::_Not_fn<int (*)(int) noexcept>>,

rpp::details::take_while_impl<int, (lambda)>, 

rpp::details::repeat_on_subscribe<int, 

rpp::specific_observable<int, 
rpp::details::lift_on_subscribe<int, 

rpp::details::map_impl<int (*)(), (lambda)>, 

rpp::observable::details::iterate_impl<std::array<int (*)(), 1>, rpp::schedulers::trampoline>>>, (lambda)>>>
```