### PR TITLE
Type erasure

### DIFF
--- a/ci/find_longest_symbols.py
+++ b/ci/find_longest_symbols.py
@@ -28,5 +28,6 @@ data = sorted(data, key=len, reverse=True)
 
 print(f"Longest line: {len(data[0])}")
 
-res = indent(data[0])
-print(res)
+for i in range(min(len(data), 10)):
+    print(f"Length: {len(data[i])}")
+    print(indent(data[i]))

--- a/ci/find_longest_symbols.py
+++ b/ci/find_longest_symbols.py
@@ -4,8 +4,9 @@ def indent(l):
     indent = 0
     for c in l:
         if c == "<":
+            res += "\n"+"\t"*indent+ c
             indent += 1
-            res += c + "\n"+"\t"*indent
+            res += "\n"+"\t"*indent
         elif c == ">":
             indent -= 1
             res += "\n"+"\t"*indent + c

--- a/ci/temp.txt
+++ b/ci/temp.txt
@@ -1,0 +1,235 @@
+Total lines: 1699
+Longest line: 2722
+    39a4:	74 25                	je     39cb 
+<
+	std::_Sp_counted_ptr_inplace
+	<
+		rpp::schedulers::details::specific_schedulable
+		<
+			rpp::details::from_iterable_schedulable
+			, rpp::observer
+			<
+				rpp::filter_observable
+				<
+					rpp::operators::details::take_while_observable
+					<
+						rpp::observable
+						<
+							int
+							, rpp::details::concat_strategy
+							<
+								rpp::utils::infinite_repeated_container
+								<
+									rpp::map_observable
+									<
+										rpp::observable
+										<
+											int (*)()
+											, rpp::details::from_iterable_strategy
+											<
+												std::array
+												<
+													int (*)()
+													, 1ul
+												>
+												, rpp::schedulers::current_thread
+											> 
+										>
+										, rpp::source::from_callable
+										<
+											rpp::memory_model::use_stack
+											, int (*)()
+										>(int (*&&)())::{lambda(auto:1&&)#1}
+									> 
+								> 
+							> 
+						>
+						, main::{lambda(char)#1}
+					>
+					, std::_Not_fn
+					<
+						int (*)(int) noexcept
+					> 
+				>
+				, rpp::operators::details::operator_strategy_base
+				<
+					rpp::observer
+					<
+						int
+						, rpp::details::observers::dynamic_strategy
+						<
+							int
+						> 
+					>
+					, rpp::operators::details::merge_observer_strategy
+					<
+						int
+					> 
+				> 
+			>
+			, std::array
+			<
+				rpp::filter_observable
+				<
+					rpp::operators::details::take_while_observable
+					<
+						rpp::observable
+						<
+							int
+							, rpp::details::concat_strategy
+							<
+								rpp::utils::infinite_repeated_container
+								<
+									rpp::map_observable
+									<
+										rpp::observable
+										<
+											int (*)()
+											, rpp::details::from_iterable_strategy
+											<
+												std::array
+												<
+													int (*)()
+													, 1ul
+												>
+												, rpp::schedulers::current_thread
+											> 
+										>
+										, rpp::source::from_callable
+										<
+											rpp::memory_model::use_stack
+											, int (*)()
+										>(int (*&&)())::{lambda(auto:1&&)#1}
+									> 
+								> 
+							> 
+						>
+						, main::{lambda(char)#1}
+					>
+					, std::_Not_fn
+					<
+						int (*)(int) noexcept
+					> 
+				>
+				, 1ul
+			>
+			, unsigned long
+		>
+		, std::allocator
+		<
+			rpp::schedulers::details::specific_schedulable
+			<
+				rpp::details::from_iterable_schedulable
+				, rpp::observer
+				<
+					rpp::filter_observable
+					<
+						rpp::operators::details::take_while_observable
+						<
+							rpp::observable
+							<
+								int
+								, rpp::details::concat_strategy
+								<
+									rpp::utils::infinite_repeated_container
+									<
+										rpp::map_observable
+										<
+											rpp::observable
+											<
+												int (*)()
+												, rpp::details::from_iterable_strategy
+												<
+													std::array
+													<
+														int (*)()
+														, 1ul
+													>
+													, rpp::schedulers::current_thread
+												> 
+											>
+											, rpp::source::from_callable
+											<
+												rpp::memory_model::use_stack
+												, int (*)()
+											>(int (*&&)())::{lambda(auto:1&&)#1}
+										> 
+									> 
+								> 
+							>
+							, main::{lambda(char)#1}
+						>
+						, std::_Not_fn
+						<
+							int (*)(int) noexcept
+						> 
+					>
+					, rpp::operators::details::operator_strategy_base
+					<
+						rpp::observer
+						<
+							int
+							, rpp::details::observers::dynamic_strategy
+							<
+								int
+							> 
+						>
+						, rpp::operators::details::merge_observer_strategy
+						<
+							int
+						> 
+					> 
+				>
+				, std::array
+				<
+					rpp::filter_observable
+					<
+						rpp::operators::details::take_while_observable
+						<
+							rpp::observable
+							<
+								int
+								, rpp::details::concat_strategy
+								<
+									rpp::utils::infinite_repeated_container
+									<
+										rpp::map_observable
+										<
+											rpp::observable
+											<
+												int (*)()
+												, rpp::details::from_iterable_strategy
+												<
+													std::array
+													<
+														int (*)()
+														, 1ul
+													>
+													, rpp::schedulers::current_thread
+												> 
+											>
+											, rpp::source::from_callable
+											<
+												rpp::memory_model::use_stack
+												, int (*)()
+											>(int (*&&)())::{lambda(auto:1&&)#1}
+										> 
+									> 
+								> 
+							>
+							, main::{lambda(char)#1}
+						>
+						, std::_Not_fn
+						<
+							int (*)(int) noexcept
+						> 
+					>
+					, 1ul
+				>
+				, unsigned long
+			> 
+		>
+		, (__gnu_cxx::_Lock_policy)2
+	>::_M_get_deleter(std::type_info const&)+0x3b
+>
+

--- a/src/examples/rpp/basic/basic.cpp
+++ b/src/examples/rpp/basic/basic.cpp
@@ -3,10 +3,11 @@
 
 int main() // NOLINT
 {
-    rpp::source::from_callable(&::getchar)
+    rpp::source::just(rpp::source::from_callable(&::getchar)
         | rpp::operators::repeat()
         | rpp::operators::take_while([](char v) { return v != '0'; })
-        | rpp::operators::filter(std::not_fn(&::isdigit))
+        | rpp::operators::filter(std::not_fn(&::isdigit)))
+        | rpp::operators::merge()
         | rpp::operators::map(&::toupper)
         | rpp::operators::subscribe([](char v) { std::cout << v; });
         

--- a/src/examples/rpp/doxygen/concat.cpp
+++ b/src/examples/rpp/doxygen/concat.cpp
@@ -1,4 +1,3 @@
-#include "rpp/sources/fwd.hpp"
 #include <rpp/rpp.hpp>
 
 #include <iostream>

--- a/src/rpp/rpp/observables/blocking_observable.hpp
+++ b/src/rpp/rpp/observables/blocking_observable.hpp
@@ -52,7 +52,7 @@ public:
     {
         std::promise<void> promise{};
         auto future = promise.get_future();
-        m_original.subscribe(observer<Type, rpp::operators::details::operator_strategy_base<Type, observer<Type, ObserverStrategy>, blocking_observer_strategy>>{std::move(obs), std::move(promise)});
+        m_original.subscribe(observer<Type, rpp::operators::details::operator_strategy_base<observer<Type, ObserverStrategy>, blocking_observer_strategy>>{std::move(obs), std::move(promise)});
         future.wait();
     }
 

--- a/src/rpp/rpp/observables/fwd.hpp
+++ b/src/rpp/rpp/observables/fwd.hpp
@@ -91,6 +91,9 @@ namespace rpp::constraint
 template<typename T>
 concept observable = rpp::utils::details::is_observable_t<std::decay_t<T>>::value;
 
+template<typename T, typename Type>
+concept observable_of_type = observable<T> && std::same_as<rpp::utils::extract_observable_type_t<T>, Type>;
+
 template<typename Op, typename TObs>
 concept operators = requires(const Op& op, TObs obs)
 {

--- a/src/rpp/rpp/observables/observable.hpp
+++ b/src/rpp/rpp/observables/observable.hpp
@@ -151,4 +151,10 @@ auto operator|(TObservable&& observable, const rpp::operators::details::subscrib
 {
     return op(std::forward<TObservable>(observable));
 }
+
+template<constraint::observable TObservable, typename...Args>
+auto operator|(TObservable&& observable, rpp::operators::details::subscribe_t<Args...>&& op)
+{
+    return std::move(op)(std::forward<TObservable>(observable));
+}
 }

--- a/src/rpp/rpp/observers/details/observer_storage.hpp
+++ b/src/rpp/rpp/observers/details/observer_storage.hpp
@@ -44,10 +44,10 @@ public:
     void set_upstream(const disposable_wrapper& d) { m_vtable->set_upstream(m_data, d); }
     bool is_disposed() const                       { return m_vtable->is_disposed(m_data); }
 
-    void on_next(const Type& v) const noexcept                     { m_vtable->on_next_lvalue(m_data, v);            }
-    void on_next(Type&& v) const noexcept                          { m_vtable->on_next_rvalue(m_data, std::move(v)); }
-    void on_error(const std::exception_ptr& err) const noexcept    { m_vtable->on_error(m_data, err);                }
-    void on_completed() const noexcept                             { m_vtable->on_completed(m_data);                 }
+    void on_next(const Type& v) const                     { m_vtable->on_next_lvalue(m_data, v);            }
+    void on_next(Type&& v) const                          { m_vtable->on_next_rvalue(m_data, std::move(v)); }
+    void on_error(const std::exception_ptr& err) const    { m_vtable->on_error(m_data, err);                }
+    void on_completed() const                             { m_vtable->on_completed(m_data);                 }
 
 
 private:

--- a/src/rpp/rpp/observers/details/observer_storage.hpp
+++ b/src/rpp/rpp/observers/details/observer_storage.hpp
@@ -9,14 +9,15 @@
 
 #pragma once
 
-#include "rpp/utils/constraints.hpp"
 #include <rpp/observers/fwd.hpp>
 #include <rpp/observers/details/observer_vtable.hpp>
+#include <rpp/utils/constraints.hpp>
 
 namespace rpp::details::observers
 {
 template<typename T>
 struct construct_with{};
+
 template<constraint::decayed_type Type, size_t size, size_t alignment>
 class type_erased_strategy final
 {

--- a/src/rpp/rpp/observers/details/observer_storage.hpp
+++ b/src/rpp/rpp/observers/details/observer_storage.hpp
@@ -22,7 +22,7 @@ class type_erased_strategy final
 {
 public:
     template<constraint::observer_strategy<Type> Strategy, typename ...Args>
-        requires(sizeof(Strategy) == size && alignof(Strategy) == alignment && !constraint::decayed_same_as<Strategy, type_erased_strategy<Type, size, alignment>> && constraint::is_constructible_from<Strategy, Args&&...>)
+        requires(sizeof(Strategy) == size && alignof(Strategy) == alignment && constraint::is_constructible_from<Strategy, Args&&...>)
     explicit type_erased_strategy(construct_with<Strategy>, Args&& ...args)
         : m_vtable{observer_vtable<Type>::template create<std::decay_t<Strategy>>()}
     {
@@ -54,7 +54,4 @@ private:
     alignas(alignment) std::byte m_data[size]{};
     const observer_vtable<Type>* m_vtable;
 };
-
-template<constraint::decayed_type Type, constraint::observer_strategy<Type> Strategy>
-using type_erased_strategy_for = type_erased_strategy<Type, sizeof(Strategy), alignof(Strategy)>;
 }

--- a/src/rpp/rpp/observers/details/observer_storage.hpp
+++ b/src/rpp/rpp/observers/details/observer_storage.hpp
@@ -20,14 +20,14 @@ class type_erased_strategy final
 public:
     template<constraint::observer_strategy<Type> Strategy>
         requires(sizeof(std::decay_t<Strategy>) == size && alignof(std::decay_t<Strategy>) == alignment && !constraint::decayed_same_as<Strategy, type_erased_strategy<Type, size, alignment>>)
-    explicit type_erased_strategy(Strategy&& str) 
+    explicit type_erased_strategy(Strategy&& str)
         : m_vtable{observer_vtable<Type>::template create<std::decay_t<Strategy>>()}
     {
-        std::construct_at(static_cast<std::decay_t<Strategy>*>(str), std::forward<Strategy>(str));
+        std::construct_at(reinterpret_cast<std::decay_t<Strategy>*>(m_data), std::forward<Strategy>(str));
     }
 
     type_erased_strategy(const type_erased_strategy&) = delete;
-    type_erased_strategy(type_erased_strategy&& other) noexcept 
+    type_erased_strategy(type_erased_strategy&& other) noexcept
         : m_vtable(other.m_vtable)
     {
         m_vtable->move_to(other.m_data, m_data);

--- a/src/rpp/rpp/observers/details/observer_storage.hpp
+++ b/src/rpp/rpp/observers/details/observer_storage.hpp
@@ -1,0 +1,57 @@
+//                   ReactivePlusPlus library
+//
+//           Copyright Aleksey Loginov 2023 - present.
+//  Distributed under the Boost Software License, Version 1.0.
+//     (See accompanying file LICENSE_1_0.txt or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+//
+//  Project home: https://github.com/victimsnino/ReactivePlusPlus
+
+#pragma once
+
+#include <rpp/observers/fwd.hpp>
+#include <rpp/observers/details/observer_vtable.hpp>
+
+namespace rpp::details::observers
+{
+template<constraint::decayed_type Type, size_t size, size_t alignment>
+class type_erased_strategy final
+{
+public:
+    template<constraint::observer_strategy<Type> Strategy>
+        requires(sizeof(std::decay_t<Strategy>) == size && alignof(std::decay_t<Strategy>) == alignment && !constraint::decayed_same_as<Strategy, type_erased_strategy<Type, size, alignment>>)
+    explicit type_erased_strategy(Strategy&& str) 
+        : m_vtable{observer_vtable<Type>::template create<std::decay_t<Strategy>>()}
+    {
+        std::construct_at(static_cast<std::decay_t<Strategy>*>(str), std::forward<Strategy>(str));
+    }
+
+    type_erased_strategy(const type_erased_strategy&) = delete;
+    type_erased_strategy(type_erased_strategy&& other) noexcept 
+        : m_vtable(other.m_vtable)
+    {
+        m_vtable->move_to(other.m_data, m_data);
+    }
+
+    ~type_erased_strategy() noexcept
+    {
+        m_vtable->destroy_at(m_data);
+    }
+
+    void set_upstream(const disposable_wrapper& d) { m_vtable->set_upstream(m_data, d); }
+    bool is_disposed() const                       { return m_vtable->is_disposed(m_data); }
+
+    void on_next(const Type& v) const noexcept                     { m_vtable->on_next_lvalue(m_data, v);            }
+    void on_next(Type&& v) const noexcept                          { m_vtable->on_next_rvalue(m_data, std::move(v)); }
+    void on_error(const std::exception_ptr& err) const noexcept    { m_vtable->on_error(m_data, err);                }
+    void on_completed() const noexcept                             { m_vtable->on_completed(m_data);                 }
+
+
+private:
+    alignas(alignment) std::byte m_data[size]{};
+    const observer_vtable<Type>* m_vtable;
+};
+
+template<constraint::decayed_type Type, constraint::observer_strategy<Type> Strategy>
+using type_erased_strategy_for = type_erased_strategy<Type, sizeof(Strategy), alignof(Strategy)>;
+}

--- a/src/rpp/rpp/observers/details/observer_vtable.hpp
+++ b/src/rpp/rpp/observers/details/observer_vtable.hpp
@@ -1,0 +1,71 @@
+//                   ReactivePlusPlus library
+//
+//           Copyright Aleksey Loginov 2023 - present.
+//  Distributed under the Boost Software License, Version 1.0.
+//     (See accompanying file LICENSE_1_0.txt or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+//
+//  Project home: https://github.com/victimsnino/ReactivePlusPlus
+
+#pragma once
+
+#include <rpp/observers/fwd.hpp>
+#include <rpp/disposables/fwd.hpp>
+
+namespace rpp::details::observers
+{
+template<typename T, typename Strategy>
+void forwarding_on_next_lvalue(const void* const ptr, const T& v) { static_cast<const Strategy*>(ptr)->on_next(v); }
+
+template<typename T, typename Strategy>
+void forwarding_on_next_rvalue(const void* const ptr, T&& v) { static_cast<const Strategy*>(ptr)->on_next(std::forward<T>(v)); }
+
+template<typename Strategy>
+void forwarding_on_error(const void* const ptr, const std::exception_ptr& err) { static_cast<const Strategy*>(ptr)->on_error(err); }
+
+template<typename Strategy>
+void forwarding_on_completed(const void* const ptr) { static_cast<const Strategy*>(ptr)->on_completed(); }
+
+template<typename Strategy>
+void forwarding_set_upstream(void* const ptr, const disposable_wrapper& d) { static_cast<Strategy*>(ptr)->set_upstream(d); }
+
+template<typename Strategy>
+bool forwarding_is_disposed(const void* const ptr) { return static_cast<const Strategy*>(ptr)->is_disposed(); }
+
+template<typename Strategy>
+void forwarding_destroy_at(void* const ptr) { std::destroy_at(static_cast<Strategy*>(ptr)); }
+
+template<typename Strategy>
+void forwarding_move_to(void* const origin, void* const dest) { std::construct_at(static_cast<Strategy*>(dest), std::move(*static_cast<Strategy*>(origin))); }
+
+template<constraint::decayed_type Type>
+struct observer_vtable
+{
+    void (*on_next_lvalue)(const void*, const Type&){};
+    void (*on_next_rvalue)(const void*, Type&&){};
+    void (*on_error)(const void*, const std::exception_ptr&){};
+    void (*on_completed)(const void*){};
+
+    void (*set_upstream)(void*, const disposable_wrapper&){};
+    bool (*is_disposed)(const void*){};
+
+    void (*destroy_at)(void*){};
+    void (*move_to)(void*, void*){};
+
+    template<constraint::observer_strategy<Type> Strategy>
+    static const observer_vtable* create() noexcept
+    {
+        static observer_vtable s_res{
+            .on_next_lvalue = forwarding_on_next_lvalue<Type, Strategy>,
+            .on_next_rvalue = forwarding_on_next_rvalue<Type, Strategy>,
+            .on_error = forwarding_on_error<Strategy>,
+            .on_completed = forwarding_on_completed<Strategy>,
+            .set_upstream = forwarding_set_upstream<Strategy>,
+            .is_disposed = forwarding_is_disposed<Strategy>,
+            .destroy_at = forwarding_destroy_at<Strategy>,
+            .move_to = forwarding_move_to<Strategy>
+        };
+        return &s_res;
+    }
+};
+}

--- a/src/rpp/rpp/observers/fwd.hpp
+++ b/src/rpp/rpp/observers/fwd.hpp
@@ -45,6 +45,12 @@ concept observer_strategy = requires(const S& const_strategy, S& strategy, const
 
 namespace rpp::details::observers
 {
+template<constraint::decayed_type Type, size_t size, size_t alignment>
+class type_erased_strategy;
+
+template<constraint::decayed_type Type, constraint::observer_strategy<Type> Strategy>
+using type_erased_strategy_for = type_erased_strategy<Type, sizeof(Strategy), alignof(Strategy)>;
+
 template<constraint::decayed_type Type>
 class dynamic_strategy;
 
@@ -98,10 +104,10 @@ using dynamic_observer = observer<Type, details::observers::dynamic_strategy<Typ
  * @ingroup observers
  */
 template<constraint::decayed_type Type, std::invocable<Type> OnNext,  std::invocable<const std::exception_ptr&> OnError, std::invocable<> OnCompleted>
-using lambda_observer = observer<Type, details::observers::lambda_strategy<Type, OnNext, OnError, OnCompleted>>;
+using lambda_observer = observer<Type, details::observers::type_erased_strategy_for<Type, details::observers::lambda_strategy<Type, OnNext, OnError, OnCompleted>>>;
 
 template<constraint::decayed_type Type, std::invocable<Type> OnNext,  std::invocable<const std::exception_ptr&> OnError, std::invocable<> OnCompleted>
-using lambda_observer_with_disposable = observer<Type, details::with_disposable<details::observers::lambda_strategy<Type, OnNext, OnError, OnCompleted>>>;
+using lambda_observer_with_disposable = observer<Type, details::with_disposable<details::observers::type_erased_strategy_for<Type, details::observers::lambda_strategy<Type, OnNext, OnError, OnCompleted>>>>;
 
 template<constraint::decayed_type Type,
          std::invocable<Type>                      OnNext,

--- a/src/rpp/rpp/observers/fwd.hpp
+++ b/src/rpp/rpp/observers/fwd.hpp
@@ -115,10 +115,7 @@ template<constraint::decayed_type Type,
          std::invocable<>                          OnCompleted = rpp::utils::empty_function_t<>>
 auto make_lambda_observer(OnNext&&      on_next,
                           OnError&&     on_error = {},
-                          OnCompleted&& on_completed = {}) -> lambda_observer<Type,
-                                                                              std::decay_t<OnNext>,
-                                                                              std::decay_t<OnError>,
-                                                                              std::decay_t<OnCompleted>>;
+                          OnCompleted&& on_completed = {});
 
 template<constraint::decayed_type Type,
          std::invocable<Type>                      OnNext,
@@ -127,10 +124,7 @@ template<constraint::decayed_type Type,
 auto make_lambda_observer(const rpp::disposable_wrapper& d,
                           OnNext&&      on_next,
                           OnError&&     on_error = {},
-                          OnCompleted&& on_completed = {}) -> lambda_observer_with_disposable<Type,
-                                                                                              std::decay_t<OnNext>,
-                                                                                              std::decay_t<OnError>,
-                                                                                              std::decay_t<OnCompleted>>;
+                          OnCompleted&& on_completed = {});
 
 template<typename                                  OnNext,
          std::invocable<const std::exception_ptr&> OnError = rpp::utils::rethrow_error_t,

--- a/src/rpp/rpp/observers/lambda_observer.hpp
+++ b/src/rpp/rpp/observers/lambda_observer.hpp
@@ -46,10 +46,7 @@ template<constraint::decayed_type Type,
          std::invocable<> OnCompleted>
 auto make_lambda_observer(OnNext&&      on_next,
                           OnError&&     on_error,
-                          OnCompleted&& on_completed) -> lambda_observer<Type,
-                                                                         std::decay_t<OnNext>,
-                                                                         std::decay_t<OnError>,
-                                                                         std::decay_t<OnCompleted>>
+                          OnCompleted&& on_completed)
 {
     return lambda_observer<Type,
                            std::decay_t<OnNext>,
@@ -67,10 +64,7 @@ template<constraint::decayed_type Type,
 auto make_lambda_observer(const rpp::disposable_wrapper& d,
                           OnNext&&      on_next,
                           OnError&&     on_error,
-                          OnCompleted&& on_completed) -> lambda_observer_with_disposable<Type,
-                                                                                         std::decay_t<OnNext>,
-                                                                                         std::decay_t<OnError>,
-                                                                                         std::decay_t<OnCompleted>>
+                          OnCompleted&& on_completed)
 {
     return lambda_observer_with_disposable<Type,
                                            std::decay_t<OnNext>,

--- a/src/rpp/rpp/observers/observer.hpp
+++ b/src/rpp/rpp/observers/observer.hpp
@@ -106,7 +106,8 @@ protected:
     template<typename... Args>
         requires constraint::is_constructible_from<Strategy, Args&&...>
     explicit observer_impl(DisposablesStrategy&& strategy, Args&&... args)
-        : m_strategy{std::forward<Args>(args)...}, m_disposable{std::move(strategy)}
+        : m_strategy{std::forward<Args>(args)...}
+        , m_disposable{std::move(strategy)}
     {
     }
 

--- a/src/rpp/rpp/operators/details/strategy.hpp
+++ b/src/rpp/rpp/operators/details/strategy.hpp
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "rpp/utils/utils.hpp"
 #include <rpp/defs.hpp>
 #include <rpp/observers/fwd.hpp>
 #include <rpp/observers/details/observer_storage.hpp>
@@ -18,6 +17,7 @@
 #include <rpp/disposables/disposable_wrapper.hpp>
 #include <rpp/observables/observable.hpp>
 #include <rpp/utils/constraints.hpp>
+#include <rpp/utils/utils.hpp>
 
 #include <exception>
 #include <functional>

--- a/src/rpp/rpp/operators/details/strategy.hpp
+++ b/src/rpp/rpp/operators/details/strategy.hpp
@@ -168,4 +168,26 @@ template<rpp::constraint::decayed_type T,
          constraint::operator_strategy<rpp::utils::extract_observable_type_t<Observable>> Strategy,
          typename... Args>
 using operator_observable = rpp::observable<T, operator_observable_strategy<std::decay_t<Observable>, Strategy, Args...>>;
-}
+
+#define RPP_OPERATOR_OBSERVBLE_IMPL(name, type, short_type, ...)                                                       \
+    class name : public type<__VA_ARGS__>                                                                              \
+    {                                                                                                                  \
+       using type<__VA_ARGS__>::short_type;                                                                            \
+                                                                                                                       \
+       template<typename Op>                                                                                           \
+       auto pipe(Op&& op) const&                                                                                       \
+       {                                                                                                               \
+           return *this | std::forward<Op>(op);                                                                        \
+       }                                                                                                               \
+       template<typename Op>                                                                                           \
+       auto pipe(Op&& op) &&                                                                                           \
+       {                                                                                                               \
+           return std::move(*this) | std::forward<Op>(op);                                                             \
+       }                                                                                                               \
+    };
+
+#define RPP_OPERATOR_OBSERVABLE(name, ...)                                                                             \
+    RPP_OPERATOR_OBSERVBLE_IMPL(name, rpp::operators::details::operator_observable, operator_observable, __VA_ARGS__)
+#define RPP_IDENTITY_OPERATOR_OBSERVABLE(name, ...)                                                                    \
+    RPP_OPERATOR_OBSERVBLE_IMPL(name, rpp::operators::details::identity_operator_observable, identity_operator_observable, __VA_ARGS__)
+} // namespace rpp::operators::details

--- a/src/rpp/rpp/operators/details/strategy.hpp
+++ b/src/rpp/rpp/operators/details/strategy.hpp
@@ -174,6 +174,7 @@ using operator_observable = rpp::observable<T, operator_observable_strategy<std:
 #define RPP_OPERATOR_OBSERVBLE_IMPL(name, type, short_type, ...)                                                       \
     class name : public type<__VA_ARGS__>                                                                              \
     {                                                                                                                  \
+   public:                                                                                                             \
        using type<__VA_ARGS__>::short_type;                                                                            \
                                                                                                                        \
        template<typename Op>                                                                                           \

--- a/src/rpp/rpp/operators/details/strategy.hpp
+++ b/src/rpp/rpp/operators/details/strategy.hpp
@@ -186,7 +186,7 @@ using operator_observable = rpp::observable<T, operator_observable_strategy<std:
        {                                                                                                               \
            return std::move(*this) | std::forward<Op>(op);                                                             \
        }                                                                                                               \
-    };
+    }
 
 #define RPP_OPERATOR_OBSERVABLE(name, ...)                                                                             \
     RPP_OPERATOR_OBSERVBLE_IMPL(name, rpp::operators::details::operator_observable, operator_observable, __VA_ARGS__)

--- a/src/rpp/rpp/operators/details/strategy.hpp
+++ b/src/rpp/rpp/operators/details/strategy.hpp
@@ -13,6 +13,7 @@
 #include "rpp/utils/utils.hpp"
 #include <rpp/defs.hpp>
 #include <rpp/observers/fwd.hpp>
+#include <rpp/observers/details/observer_storage.hpp>
 #include <rpp/sources/fwd.hpp>
 #include <rpp/disposables/disposable_wrapper.hpp>
 #include <rpp/observables/observable.hpp>
@@ -147,8 +148,9 @@ public:
     {
        std::apply([&obs, this](const Args&... vals)
                   {
-                        m_observable.subscribe(observer<rpp::utils::extract_observable_type_t<Observable>,
-                                                            operator_strategy_base<std::decay_t<TObs>, Strategy>>{std::forward<TObs>(obs), vals...});
+                    using NewStrategy = operator_strategy_base<std::decay_t<TObs>, Strategy>;
+                    using TypeErasedStrategy = rpp::details::observers::type_erased_strategy_for<rpp::utils::extract_observable_type_t<Observable>, NewStrategy>;
+                    m_observable.subscribe(observer<rpp::utils::extract_observable_type_t<Observable>, TypeErasedStrategy>{rpp::details::observers::construct_with<NewStrategy>{}, std::forward<TObs>(obs), vals...});
                   },
                   m_vals);
     }

--- a/src/rpp/rpp/operators/distinct_until_changed.hpp
+++ b/src/rpp/rpp/operators/distinct_until_changed.hpp
@@ -19,6 +19,17 @@
 namespace rpp::operators::details
 {
 template<rpp::constraint::decayed_type Type, rpp::constraint::decayed_type EqualityFn>
+struct distinct_until_changed_observer_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>, rpp::utils::extract_observable_type_t<TObservable>> Fn>
+RPP_IDENTITY_OPERATOR_OBSERVABLE(distinct_until_changed_observable, std::decay_t<TObservable>, operators::details::distinct_until_changed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn)
+}
+namespace rpp::operators::details
+{
+template<rpp::constraint::decayed_type Type, rpp::constraint::decayed_type EqualityFn>
 struct distinct_until_changed_observer_strategy
 {
     RPP_NO_UNIQUE_ADDRESS EqualityFn comparator;
@@ -40,11 +51,6 @@ struct distinct_until_changed_observer_strategy
     constexpr static forwarding_is_disposed_strategy is_disposed{};
     constexpr static empty_on_subscribe on_subscribe{};
 };
-
-
-template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>, rpp::utils::extract_observable_type_t<TObservable>> Fn>
-using distinct_until_changed_observable = identity_operator_observable<std::decay_t<TObservable>, distinct_until_changed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn>;
-
 
 template<rpp::constraint::decayed_type EqualityFn>
 struct distinct_until_changed_t

--- a/src/rpp/rpp/operators/distinct_until_changed.hpp
+++ b/src/rpp/rpp/operators/distinct_until_changed.hpp
@@ -25,7 +25,7 @@ struct distinct_until_changed_observer_strategy;
 namespace rpp
 {
 template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>, rpp::utils::extract_observable_type_t<TObservable>> Fn>
-RPP_IDENTITY_OPERATOR_OBSERVABLE(distinct_until_changed_observable, std::decay_t<TObservable>, operators::details::distinct_until_changed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn)
+RPP_IDENTITY_OPERATOR_OBSERVABLE(distinct_until_changed_observable, std::decay_t<TObservable>, operators::details::distinct_until_changed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn);
 }
 namespace rpp::operators::details
 {

--- a/src/rpp/rpp/operators/filter.hpp
+++ b/src/rpp/rpp/operators/filter.hpp
@@ -19,6 +19,17 @@
 namespace rpp::operators::details
 {
 template<rpp::constraint::decayed_type Fn>
+struct filter_observer_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>> Fn>
+RPP_IDENTITY_OPERATOR_OBSERVABLE(filter_observable, std::decay_t<TObservable>, operators::details::filter_observer_strategy<Fn>, Fn);
+}
+namespace rpp::operators::details
+{
+template<rpp::constraint::decayed_type Fn>
 struct filter_observer_strategy
 {
     RPP_NO_UNIQUE_ADDRESS Fn fn;
@@ -36,11 +47,6 @@ struct filter_observer_strategy
     constexpr static forwarding_is_disposed_strategy is_disposed{};
     constexpr static empty_on_subscribe on_subscribe{};
 };
-
-
-template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>> Fn>
-using filter_observable = identity_operator_observable<std::decay_t<TObservable>, filter_observer_strategy<Fn>, Fn>;
-
 
 template<rpp::constraint::decayed_type Fn>
 struct filter_t

--- a/src/rpp/rpp/operators/map.hpp
+++ b/src/rpp/rpp/operators/map.hpp
@@ -18,6 +18,18 @@
 namespace rpp::operators::details
 {
 template<rpp::constraint::decayed_type Fn>
+struct map_observer_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>> Fn>
+RPP_OPERATOR_OBSERVABLE(map_observable, std::invoke_result_t<Fn, rpp::utils::extract_observable_type_t<TObservable>>, TObservable, operators::details::map_observer_strategy<Fn>, Fn);
+}
+
+namespace rpp::operators::details
+{
+template<rpp::constraint::decayed_type Fn>
 struct map_observer_strategy
 {
     RPP_NO_UNIQUE_ADDRESS Fn fn;
@@ -35,13 +47,6 @@ struct map_observer_strategy
     constexpr static empty_on_subscribe on_subscribe{};
 
 };
-
-template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>> Fn>
-using map_observable = operator_observable<std::invoke_result_t<Fn, rpp::utils::extract_observable_type_t<TObservable>>,
-                                           TObservable,
-                                           map_observer_strategy<Fn>,
-                                           Fn>;
-
 
 template<rpp::constraint::decayed_type Fn>
 struct map_t

--- a/src/rpp/rpp/operators/merge.hpp
+++ b/src/rpp/rpp/operators/merge.hpp
@@ -22,6 +22,18 @@
 
 namespace rpp::operators::details
 {
+template<rpp::constraint::observable Observable>
+class merge_observable_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable>
+RPP_OPERATOR_OBSERVBLE_IMPL(merge_observable, rpp::observable, observable, rpp::utils::extract_observable_type_t<rpp::utils::extract_observable_type_t<TObservable>>, operators::details::merge_observable_strategy<TObservable>);
+}
+
+namespace rpp::operators::details
+{
 template<typename Lock>
 class merge_disposable final : public base_disposable
 {
@@ -152,9 +164,6 @@ public:
 private:
     RPP_NO_UNIQUE_ADDRESS Observable m_observable;
 };
-
-template<rpp::constraint::observable TObservable>
-using merge_observable = rpp::observable<rpp::utils::extract_observable_type_t<rpp::utils::extract_observable_type_t<TObservable>>, merge_observable_strategy<TObservable>>;
 
 struct merge_t
 {

--- a/src/rpp/rpp/operators/merge.hpp
+++ b/src/rpp/rpp/operators/merge.hpp
@@ -24,12 +24,20 @@ namespace rpp::operators::details
 {
 template<rpp::constraint::observable Observable>
 class merge_observable_strategy;
+
+template<rpp::constraint::observable TObservable, rpp::constraint::observable... TObservables>
+    requires rpp::constraint::observables_of_same_type<std::decay_t<TObservable>, std::decay_t<TObservables>...>
+class merge_with_observable_strategy;
 }
 
 namespace rpp
 {
 template<rpp::constraint::observable TObservable>
 RPP_OPERATOR_OBSERVBLE_IMPL(merge_observable, rpp::observable, observable, rpp::utils::extract_observable_type_t<rpp::utils::extract_observable_type_t<TObservable>>, operators::details::merge_observable_strategy<TObservable>);
+
+template<rpp::constraint::observable TObservable, rpp::constraint::observable... TObservables>
+RPP_OPERATOR_OBSERVBLE_IMPL(merge_with_observable, rpp::observable, observable, rpp::utils::extract_observable_type_t<TObservable>, operators::details::merge_with_observable_strategy<TObservable, TObservables...>);
+
 }
 
 namespace rpp::operators::details
@@ -206,9 +214,6 @@ public:
 private:
     std::tuple<TObservable, TObservables...> m_observables{};
 };
-
-template<rpp::constraint::observable TObservable, rpp::constraint::observable... TObservables>
-using merge_with_observable = rpp::observable<rpp::utils::extract_observable_type_t<TObservable>, merge_with_observable_strategy<TObservable, TObservables...>>;
 
 template<rpp::constraint::observable... TObservables>
 struct merge_with_t

--- a/src/rpp/rpp/operators/merge.hpp
+++ b/src/rpp/rpp/operators/merge.hpp
@@ -104,7 +104,7 @@ struct merge_observer_strategy
     void on_next(rpp::dynamic_observer<Value> obs, T&& v) const
     {
         disposable->increment_on_completed();
-        std::forward<T>(v).subscribe(rpp::observer<Value, operator_strategy_base<Value, rpp::dynamic_observer<Value>, merge_observer_inner_strategy>>{std::move(obs), disposable});
+        std::forward<T>(v).subscribe(rpp::observer<Value, operator_strategy_base<rpp::dynamic_observer<Value>, merge_observer_inner_strategy>>{std::move(obs), disposable});
     }
 
     void on_error(const rpp::constraint::observer auto & obs, const std::exception_ptr& err) const
@@ -146,7 +146,7 @@ public:
         // Need to take ownership over current_thread in case of inner-observables also uses them
         auto drain_on_exit = rpp::schedulers::current_thread::own_queue_and_drain_finally_if_not_owned();
 
-        m_observable.subscribe(rpp::observer<InnerObservable, operator_strategy_base<InnerObservable, rpp::dynamic_observer<Value>, merge_observer_strategy<Value>>>{std::move(obs).as_dynamic()});
+        m_observable.subscribe(rpp::observer<InnerObservable, operator_strategy_base<rpp::dynamic_observer<Value>, merge_observer_strategy<Value>>>{std::move(obs).as_dynamic()});
     }
 
 private:

--- a/src/rpp/rpp/operators/scan.hpp
+++ b/src/rpp/rpp/operators/scan.hpp
@@ -46,7 +46,7 @@ struct scan_observer_strategy
 };
 
 template<rpp::constraint::observable TObservable, rpp::constraint::decayed_type InitialValue, std::invocable<InitialValue&&, rpp::utils::extract_observable_type_t<TObservable>> Fn>
-using scan_observable = operator_observable<InitialValue, TObservable, scan_observer_strategy<InitialValue, Fn>, InitialValue, Fn>;
+RPP_OPERATOR_OBSERVABLE(scan_observable, InitialValue, TObservable, scan_observer_strategy<InitialValue, Fn>, InitialValue, Fn);
 
 
 template<rpp::constraint::decayed_type InitialValue, rpp::constraint::decayed_type Fn>
@@ -95,7 +95,7 @@ struct scan_no_seed_observer_strategy
 };
 
 template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>&&, rpp::utils::extract_observable_type_t<TObservable>> Fn>
-using scan_no_seed_observable = identity_operator_observable<TObservable, scan_no_seed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn>;
+RPP_IDENTITY_OPERATOR_OBSERVABLE(scan_no_seed_observable, TObservable, scan_no_seed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn);
 
 template<rpp::constraint::decayed_type Fn>
 struct scan_no_seed_t

--- a/src/rpp/rpp/operators/scan.hpp
+++ b/src/rpp/rpp/operators/scan.hpp
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include "rpp/utils/constraints.hpp"
-#include "rpp/utils/utils.hpp"
+#include <rpp/utils/constraints.hpp>
+#include <rpp/utils/utils.hpp>
 #include <rpp/operators/fwd.hpp>
 #include <rpp/defs.hpp>
 #include <rpp/operators/details/strategy.hpp>

--- a/src/rpp/rpp/operators/scan.hpp
+++ b/src/rpp/rpp/operators/scan.hpp
@@ -18,6 +18,24 @@
 #include <cstddef>
 #include <optional>
 
+
+namespace rpp::operators::details
+{
+template<rpp::constraint::decayed_type Seed, rpp::constraint::decayed_type Fn>
+struct scan_observer_strategy;
+
+template<rpp::constraint::decayed_type Seed, rpp::constraint::decayed_type Fn>
+struct scan_no_seed_observer_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>&&, rpp::utils::extract_observable_type_t<TObservable>> Fn>
+RPP_IDENTITY_OPERATOR_OBSERVABLE(scan_no_seed_observable, TObservable, operators::details::scan_no_seed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn);
+
+template<rpp::constraint::observable TObservable, rpp::constraint::decayed_type InitialValue, std::invocable<InitialValue&&, rpp::utils::extract_observable_type_t<TObservable>> Fn>
+RPP_OPERATOR_OBSERVABLE(scan_observable, InitialValue, TObservable, operators::details::scan_observer_strategy<InitialValue, Fn>, InitialValue, Fn);
+}
 namespace rpp::operators::details
 {
 template<rpp::constraint::decayed_type Seed, rpp::constraint::decayed_type Fn>
@@ -44,10 +62,6 @@ struct scan_observer_strategy
     constexpr static forwarding_is_disposed_strategy is_disposed{};
 
 };
-
-template<rpp::constraint::observable TObservable, rpp::constraint::decayed_type InitialValue, std::invocable<InitialValue&&, rpp::utils::extract_observable_type_t<TObservable>> Fn>
-RPP_OPERATOR_OBSERVABLE(scan_observable, InitialValue, TObservable, scan_observer_strategy<InitialValue, Fn>, InitialValue, Fn);
-
 
 template<rpp::constraint::decayed_type InitialValue, rpp::constraint::decayed_type Fn>
 struct scan_t
@@ -94,8 +108,6 @@ struct scan_no_seed_observer_strategy
     constexpr static empty_on_subscribe on_subscribe{};
 };
 
-template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>&&, rpp::utils::extract_observable_type_t<TObservable>> Fn>
-RPP_IDENTITY_OPERATOR_OBSERVABLE(scan_no_seed_observable, TObservable, scan_no_seed_observer_strategy<rpp::utils::extract_observable_type_t<TObservable>, Fn>, Fn);
 
 template<rpp::constraint::decayed_type Fn>
 struct scan_no_seed_t

--- a/src/rpp/rpp/operators/skip.hpp
+++ b/src/rpp/rpp/operators/skip.hpp
@@ -17,6 +17,17 @@
 
 namespace rpp::operators::details
 {
+struct skip_observer_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable>
+RPP_IDENTITY_OPERATOR_OBSERVABLE(skip_observable, std::decay_t<TObservable>, operators::details::skip_observer_strategy, size_t);
+}
+
+namespace rpp::operators::details
+{
 struct skip_observer_strategy
 {
     mutable size_t count{};
@@ -37,9 +48,6 @@ struct skip_observer_strategy
     constexpr static empty_on_subscribe on_subscribe{};
 
 };
-
-template<rpp::constraint::observable TObservable>
-using skip_observable = details::identity_operator_observable<std::decay_t<TObservable>, details::skip_observer_strategy, size_t>;
 
 struct skip_t
 {

--- a/src/rpp/rpp/operators/subscribe.hpp
+++ b/src/rpp/rpp/operators/subscribe.hpp
@@ -31,8 +31,8 @@ public:
         : m_observer{std::move(observer)} {}
 
 
-    template<rpp::constraint::observable_strategy<Type> Strategy>
-    void operator()(const rpp::observable<Type, Strategy>& observalbe) && {
+    template<rpp::constraint::observable_of_type<Type> TObservable>
+    void operator()(const TObservable& observalbe) && {
         if (!m_observer.is_disposed())
             observalbe.subscribe(std::move(m_observer));
     }
@@ -49,8 +49,8 @@ public:
         : m_disposable{std::move(d)}
         , m_observer{std::move(observer)} {}
 
-    template<rpp::constraint::observable_strategy<Type> Strategy>
-    rpp::disposable_wrapper operator()(const rpp::observable<Type, Strategy>& observalbe) && {
+    template<rpp::constraint::observable_of_type<Type> TObservable>
+    rpp::disposable_wrapper operator()(const TObservable& observalbe) && {
         if (!m_disposable.is_disposed() && !m_observer.is_disposed())
             observalbe.subscribe(observer<Type, rpp::details::with_disposable<observer<Type, ObserverStrategy>>>{m_disposable, std::move(m_observer)});
         return m_disposable;
@@ -74,18 +74,18 @@ public:
     {
     }
 
-    template<rpp::constraint::decayed_type Type, rpp::constraint::observable_strategy<Type> Strategy>
-        requires std::invocable<OnNext, Type>
-    void operator()(const rpp::observable<Type, Strategy>& observalbe) &&
+    template<rpp::constraint::observable TObservable>
+        requires std::invocable<OnNext, rpp::utils::extract_observable_type_t<TObservable>>
+    void operator()(const TObservable& observalbe) &&
     {
-        observalbe.subscribe(make_lambda_observer<Type>(std::move(m_on_next), std::move(m_on_error), std::move(m_on_completed)));
+        observalbe.subscribe(make_lambda_observer<rpp::utils::extract_observable_type_t<TObservable>>(std::move(m_on_next), std::move(m_on_error), std::move(m_on_completed)));
     }
 
-    template<rpp::constraint::decayed_type Type, rpp::constraint::observable_strategy<Type> Strategy>
-        requires std::invocable<OnNext, Type>
-    void operator()(const rpp::observable<Type, Strategy>& observalbe) const &
+    template<rpp::constraint::observable TObservable>
+        requires std::invocable<OnNext, rpp::utils::extract_observable_type_t<TObservable>>
+    void operator()(const TObservable& observalbe) const &
     {
-        observalbe.subscribe(make_lambda_observer<Type>(m_on_next, m_on_error, m_on_completed));
+        observalbe.subscribe(make_lambda_observer<rpp::utils::extract_observable_type_t<TObservable>>(m_on_next, m_on_error, m_on_completed));
     }
 
 private:
@@ -108,21 +108,21 @@ public:
     {
     }
 
-    template<rpp::constraint::decayed_type Type, rpp::constraint::observable_strategy<Type> Strategy>
-        requires std::invocable<OnNext, Type>
-    rpp::disposable_wrapper operator()(const rpp::observable<Type, Strategy>& observalbe) &&
+    template<rpp::constraint::observable TObservable>
+        requires std::invocable<OnNext, rpp::utils::extract_observable_type_t<TObservable>>
+    rpp::disposable_wrapper operator()(const TObservable& observalbe) &&
     {
         if (!m_disposable.is_disposed())
-            observalbe.subscribe(make_lambda_observer<Type>(m_disposable, std::move(m_on_next), std::move(m_on_error), std::move(m_on_completed)));
+            observalbe.subscribe(make_lambda_observer<rpp::utils::extract_observable_type_t<TObservable>>(m_disposable, std::move(m_on_next), std::move(m_on_error), std::move(m_on_completed)));
         return std::move(m_disposable);
     }
 
-    template<rpp::constraint::decayed_type Type, rpp::constraint::observable_strategy<Type> Strategy>
-        requires std::invocable<OnNext, Type>
-    rpp::disposable_wrapper operator()(const rpp::observable<Type, Strategy>& observalbe) const &
+    template<rpp::constraint::observable TObservable>
+        requires std::invocable<OnNext, rpp::utils::extract_observable_type_t<TObservable>>
+    rpp::disposable_wrapper operator()(const TObservable& observalbe) const &
     {
         if (!m_disposable.is_disposed())
-            observalbe.subscribe(make_lambda_observer<Type>(m_disposable, m_on_next, m_on_error, m_on_completed));
+            observalbe.subscribe(make_lambda_observer<rpp::utils::extract_observable_type_t<TObservable>>(m_disposable, m_on_next, m_on_error, m_on_completed));
         return m_disposable;
     }
 

--- a/src/rpp/rpp/operators/take.hpp
+++ b/src/rpp/rpp/operators/take.hpp
@@ -17,6 +17,17 @@
 
 namespace rpp::operators::details
 {
+struct take_observer_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable>
+RPP_IDENTITY_OPERATOR_OBSERVABLE(take_observable, std::decay_t<TObservable>, operators::details::take_observer_strategy, size_t);
+}
+
+namespace rpp::operators::details
+{
 struct take_observer_strategy
 {
     mutable size_t count{};
@@ -41,9 +52,6 @@ struct take_observer_strategy
     constexpr static empty_on_subscribe on_subscribe{};
 
 };
-
-template<rpp::constraint::observable TObservable>
-using take_observable = details::identity_operator_observable<std::decay_t<TObservable>, details::take_observer_strategy, size_t>;
 
 struct take_t
 {

--- a/src/rpp/rpp/operators/take_while.hpp
+++ b/src/rpp/rpp/operators/take_while.hpp
@@ -17,6 +17,18 @@
 namespace rpp::operators::details
 {
 template<rpp::constraint::decayed_type Fn>
+struct take_while_observer_strategy;
+}
+
+namespace rpp
+{
+template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>> Fn>
+RPP_IDENTITY_OPERATOR_OBSERVABLE(take_while_observable, std::decay_t<TObservable>, operators::details::take_while_observer_strategy<Fn>, Fn);
+}
+
+namespace rpp::operators::details
+{
+template<rpp::constraint::decayed_type Fn>
 struct take_while_observer_strategy
 {
     RPP_NO_UNIQUE_ADDRESS Fn fn;
@@ -37,11 +49,6 @@ struct take_while_observer_strategy
     constexpr static empty_on_subscribe on_subscribe{};
 
 };
-
-
-template<rpp::constraint::observable TObservable, std::invocable<rpp::utils::extract_observable_type_t<TObservable>> Fn>
-using take_while_observable = identity_operator_observable<std::decay_t<TObservable>, take_while_observer_strategy<Fn>, Fn>;
-
 
 template<rpp::constraint::decayed_type Fn>
 struct take_while_t

--- a/src/rpp/rpp/sources/concat.hpp
+++ b/src/rpp/rpp/sources/concat.hpp
@@ -99,7 +99,6 @@ struct concat_strategy
         else
             observable->subscribe(observer<Type,
                                            rpp::operators::details::operator_strategy_base<
-                                               Type,
                                                observer<Type, Strategy>,
                                                concat_source_observer_strategy<PackedContainer>>>{std::move(obs),
                                                                                                   std::forward<decltype(container)>(container),

--- a/src/rpp/rpp/sources/concat.hpp
+++ b/src/rpp/rpp/sources/concat.hpp
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include "rpp/observers/details/observer_storage.hpp"
-#include "rpp/utils/constraints.hpp"
+#include <rpp/observers/details/observer_storage.hpp>
+#include <rpp/utils/constraints.hpp>
 #include <rpp/sources/fwd.hpp>
 #include <rpp/sources/from.hpp>
 #include <rpp/observables/observable.hpp>

--- a/src/rpp/rpp/sources/concat.hpp
+++ b/src/rpp/rpp/sources/concat.hpp
@@ -25,7 +25,14 @@ namespace rpp::details
 {
 template<constraint::decayed_type PackedContainer>
 struct concat_strategy;
-
+}
+namespace rpp
+{
+template<typename PackedContainer>
+RPP_OPERATOR_OBSERVBLE_IMPL(concat_observable, rpp::observable, observable, utils::extract_observable_type_t<utils::iterable_value_t<std::decay_t<PackedContainer>>>, details::concat_strategy<std::decay_t<PackedContainer>>);
+}
+namespace rpp::details
+{
 template<constraint::decayed_type PackedContainer>
 struct concat_source_observer_strategy
 {
@@ -80,7 +87,7 @@ struct concat_strategy
                 observable.emplace(*itr);
                 is_last_observable = std::next(itr) == std::cend(container);
             }
-            
+
         }
         catch (...)
         {
@@ -109,8 +116,7 @@ struct concat_strategy
 template<typename PackedContainer, typename ...Args>
 auto make_concat_from_iterable(Args&& ...args)
 {
-    return observable<utils::extract_observable_type_t<utils::iterable_value_t<std::decay_t<PackedContainer>>>,
-                           concat_strategy<std::decay_t<PackedContainer>>>{std::forward<Args>(args)...};
+    return concat_observable<std::decay_t<PackedContainer>>{std::forward<Args>(args)...};
 }
 } // namespace rpp::details
 namespace rpp::source

--- a/src/rpp/rpp/sources/concat.hpp
+++ b/src/rpp/rpp/sources/concat.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "rpp/observers/details/observer_storage.hpp"
 #include "rpp/utils/constraints.hpp"
 #include <rpp/sources/fwd.hpp>
 #include <rpp/sources/from.hpp>
@@ -104,12 +105,13 @@ struct concat_strategy
         if (is_last_observable)
             observable->subscribe(std::move(obs));
         else
-            observable->subscribe(observer<Type,
-                                           rpp::operators::details::operator_strategy_base<
+        {
+            using NewStrategy = rpp::operators::details::operator_strategy_base<
                                                observer<Type, Strategy>,
-                                               concat_source_observer_strategy<PackedContainer>>>{std::move(obs),
-                                                                                                  std::forward<decltype(container)>(container),
-                                                                                                  index});
+                                               concat_source_observer_strategy<PackedContainer>>;
+            using TypeErasedStrategy = rpp::details::observers::type_erased_strategy_for<Type, NewStrategy>;
+            observable->subscribe(observer<Type, TypeErasedStrategy>{details::observers::construct_with<NewStrategy>{}, std::move(obs), std::forward<decltype(container)>(container), index});
+        }
     }
 };
 

--- a/src/rpp/rpp/sources/create.hpp
+++ b/src/rpp/rpp/sources/create.hpp
@@ -11,6 +11,7 @@
 
 #include <rpp/sources/fwd.hpp>
 #include <rpp/observables/observable.hpp>
+#include <rpp/operators/details/strategy.hpp>
 
 namespace rpp::details
 {
@@ -24,7 +25,7 @@ struct create_strategy
 namespace rpp
 {
 template<constraint::decayed_type Type, constraint::on_subscribe<Type> OnSubscribe>
-using create_observable = observable<Type, details::create_strategy<Type, OnSubscribe>>;
+RPP_OPERATOR_OBSERVBLE_IMPL(create_observable, observable, observable, Type, details::create_strategy<Type, OnSubscribe>);
 }
 
 namespace rpp::source

--- a/src/rpp/rpp/sources/from.hpp
+++ b/src/rpp/rpp/sources/from.hpp
@@ -134,8 +134,7 @@ struct from_iterable_strategy
 template<typename PackedContainer, schedulers::constraint::scheduler TScheduler, typename ...Args>
 auto make_from_iterable_observable(const TScheduler& scheduler, Args&& ...args)
 {
-    return observable<utils::iterable_value_t<std::decay_t<PackedContainer>>,
-                           details::from_iterable_strategy<std::decay_t<PackedContainer>, TScheduler>>{scheduler, std::forward<Args>(args)...};
+    return from_observable<PackedContainer, TScheduler>{scheduler, std::forward<Args>(args)...};
 }
 } // namespace rpp::details
 

--- a/src/rpp/rpp/sources/from.hpp
+++ b/src/rpp/rpp/sources/from.hpp
@@ -24,6 +24,17 @@
 
 namespace rpp::details
 {
+template<constraint::decayed_type PackedContainer, schedulers::constraint::scheduler TScheduler>
+struct from_iterable_strategy;
+}
+namespace rpp
+{
+template<typename PackedContainer, schedulers::constraint::scheduler TScheduler>
+RPP_OPERATOR_OBSERVBLE_IMPL(from_observable, rpp::observable, observable, utils::iterable_value_t<std::decay_t<PackedContainer>>, details::from_iterable_strategy<std::decay_t<PackedContainer>, TScheduler>);
+}
+
+namespace rpp::details
+{
 template<constraint::decayed_type Container>
 class shared_container
 {


### PR DESCRIPTION
Attempt to reduce binary overhead:
1) simplify observable's types: from rpp::observable<SOME_TYPE, rpp::details::operator_observable_strategy<SOME_TYPE, PREV_OBSERVABLE, STRATEGY>> to rpp::STRATEGY_observable<SOME_TYPE, PREV_OBSERVABLE>.
2) erase observer's exact type via type-erased storage, but with keeping actual size of object