### PR TITLE
Fix refcount

### DIFF
--- a/src/rpp/rpp/disposables/details/base_disposable.hpp
+++ b/src/rpp/rpp/disposables/details/base_disposable.hpp
@@ -17,12 +17,13 @@
 
 namespace rpp::details
 {
-class base_disposable : public interface_disposable
+template<typename base_interface>
+class base_disposable_impl : public base_interface
 {
 public:
-    base_disposable()                           = default;
-    base_disposable(const base_disposable&)     = delete;
-    base_disposable(base_disposable&&) noexcept = delete;
+    base_disposable_impl()                                = default;
+    base_disposable_impl(const base_disposable_impl&)     = delete;
+    base_disposable_impl(base_disposable_impl&&) noexcept = delete;
 
     bool is_disposed() const noexcept final { return m_disposed.load(std::memory_order_acquire); }
 
@@ -38,4 +39,7 @@ protected:
 private:
     std::atomic_bool m_disposed{};
 };
+
+using base_disposable = base_disposable_impl<interface_disposable>;
+using base_composite_disposable = base_disposable_impl<interface_composite_disposable>;
 }

--- a/src/rpp/rpp/disposables/refcount_disposable.hpp
+++ b/src/rpp/rpp/disposables/refcount_disposable.hpp
@@ -26,7 +26,7 @@ namespace rpp
  *
  * @ingroup disposables
  */
-class refcount_disposable : public details::base_composite_disposable, public std::enable_shared_from_this<refcount_disposable>
+class refcount_disposable : public details::base_composite_disposable
 {
     struct state_t
     {
@@ -41,7 +41,7 @@ public:
     refcount_disposable(const refcount_disposable&)     = delete;
     refcount_disposable(refcount_disposable&&) noexcept = delete;
 
-    bool is_disposed_underlying() const noexcept { return m_state->refcount.load(std::memory_order_acquire) == 0; }
+    bool is_disposed_underlying() const noexcept { return m_state->refcount.load(std::memory_order_relaxed) == 0; }
 
     void dispose_impl() noexcept final
     {

--- a/src/rpp/rpp/observables/connectable_observable.hpp
+++ b/src/rpp/rpp/observables/connectable_observable.hpp
@@ -26,8 +26,8 @@ struct ref_count_on_subscribe_t<rpp::connectable_observable<OriginalObservable, 
     rpp::connectable_observable<OriginalObservable, Subject> original_observable{};
     struct state_t
     {
-        std::mutex                                 mutex{};
-        std::shared_ptr<rpp::refcount_disposable>  disposable{};
+        std::mutex                              mutex{};
+        std::optional<rpp::refcount_disposable> disposable{};
     };
 
     std::shared_ptr<state_t> m_state = std::make_shared<state_t>();
@@ -36,28 +36,25 @@ struct ref_count_on_subscribe_t<rpp::connectable_observable<OriginalObservable, 
     template<constraint::observer_strategy<ValueType> Strategy>
     void subscribe(observer<ValueType, Strategy>&& obs) const
     {
-        const auto [should_connect, disposable] = on_subscribe();
+        auto [disposable, upstream] = on_subscribe();
 
         obs.set_upstream(disposable);
         original_observable.subscribe(std::move(obs));
-        if (should_connect)
-            original_observable.connect(disposable);
+        if (upstream)
+            original_observable.connect(std::move(upstream));
     }
 
 private:
-    struct on_subscribe_res
-    {
-        bool                              should_connect{};
-        rpp::composite_disposable_wrapper disposable{};
-    };
 
-    on_subscribe_res on_subscribe()  const
+    std::pair<rpp::refcount_disposable, std::optional<rpp::composite_disposable_wrapper>> on_subscribe()  const
     {
         std::unique_lock lock(m_state->mutex);
-        if (m_state->disposable && !m_state->disposable->is_disposed())
-            return {.should_connect=false, .disposable=m_state->disposable->add_ref()};
-        m_state->disposable = std::make_shared<rpp::refcount_disposable>();
-        return {.should_connect=true, .disposable=m_state->disposable};
+        if (m_state->disposable && !m_state->disposable->is_disposed_underlying())
+            return {m_state->disposable->add_ref(), std::nullopt};
+
+        rpp::composite_disposable_wrapper upstream = std::make_shared<rpp::composite_disposable>();
+        m_state->disposable = rpp::refcount_disposable(upstream);
+        return {m_state->disposable.value(), upstream};
     }
 };
 }
@@ -89,7 +86,7 @@ public:
 
         if (!m_state->disposable.is_disposed())
             return m_state->disposable;
-        
+
         if (!wrapper.has_underlying())
             wrapper = rpp::composite_disposable_wrapper{std::make_shared<rpp::composite_disposable>()};
 
@@ -103,10 +100,10 @@ public:
     /**
     * @brief Forces rpp::connectable_observable to behave like common observable
     * @details Connects rpp::connectable_observable on the first subscription and unsubscribes on last unsubscription
-    *	
+    *
     * @par Example
     * @snippet ref_count.cpp ref_count
-    * 
+    *
     * @ingroup connectable_operators
     * @see https://reactivex.io/documentation/operators/refcount.html
     */

--- a/src/rpp/rpp/operators/group_by.hpp
+++ b/src/rpp/rpp/operators/group_by.hpp
@@ -41,7 +41,7 @@ struct group_by_inner_observer_strategy
     using DisposableStrategyToUseWithThis = rpp::details::none_disposable_strategy;
 
     RPP_NO_UNIQUE_ADDRESS TObserver    observer;
-    std::weak_ptr<refcount_disposable> disposable;
+    rpp::composite_disposable_wrapper disposable;
 
     template<typename T>
     void on_next(T&& v) const                          { observer.on_next(std::forward<T>(v)); }
@@ -49,11 +49,7 @@ struct group_by_inner_observer_strategy
     void on_completed() const                          { observer.on_completed(); }
 
     bool is_disposed() const                             { return observer.is_disposed(); }
-    void set_upstream(const disposable_wrapper& d) const 
-    { 
-        if (const auto locked = disposable.lock()) 
-            locked->add(d); 
-    }
+    void set_upstream(const disposable_wrapper& d) const { disposable.add(d); }
 };
 
 template<rpp::constraint::decayed_type T, rpp::constraint::observer TObserver, rpp::constraint::decayed_type KeySelector, rpp::constraint::decayed_type ValueSelector, rpp::constraint::decayed_type KeyComparator>
@@ -84,7 +80,7 @@ struct group_by_observer_strategy
 
     bool is_disposed() const
     {
-        return disposable->is_disposed();
+        return disposable->is_disposed_underlying();
     }
 
     template<rpp::constraint::decayed_same_as<T> TT>
@@ -115,7 +111,7 @@ struct group_by_observer_strategy
         observer.on_completed();
     }
 
-private:    
+private:
     template<rpp::constraint::decayed_same_as<T> TT>
     const subjects::publish_subject<Type>* deduce_subject(const rpp::constraint::observer auto& obs, const TT& val) const
     {
@@ -131,7 +127,7 @@ private:
 
         if (inserted)
         {
-            disposable->add(itr->second.get_disposable().get_original());
+            disposable->add(itr->second.get_disposable());
             obs.on_next(rpp::grouped_observable_group_by<TKey, Type>{std::move(key), group_by_observable_strategy<Type>{itr->second, disposable}});
         }
 
@@ -152,9 +148,9 @@ struct group_by_observable_strategy
     {
         if (const auto locked = disposable.lock())
         {
-            obs.set_upstream(rpp::disposable_wrapper::from_weak(locked->add_ref().get_original()));
+            obs.set_upstream(locked->add_ref());
             subj.get_observable()
-                .subscribe(rpp::observer<T, group_by_inner_observer_strategy<observer<T, Strategy>>>{std::move(obs), disposable});
+                .subscribe(rpp::observer<T, group_by_inner_observer_strategy<observer<T, Strategy>>>{std::move(obs), rpp::composite_disposable_wrapper::from_weak(disposable)});
         }
     }
 };

--- a/src/rpp/rpp/operators/group_by.hpp
+++ b/src/rpp/rpp/operators/group_by.hpp
@@ -127,7 +127,7 @@ private:
 
         if (inserted)
         {
-            disposable->add(rpp::disposable_wrapper::from_weak(itr->second.get_disposable()));
+            disposable->add(rpp::disposable_wrapper::from_weak(itr->second.get_disposable().get_original()));
             obs.on_next(rpp::grouped_observable_group_by<TKey, Type>{std::move(key), group_by_observable_strategy<Type>{itr->second, disposable}});
         }
 

--- a/src/rpp/rpp/operators/group_by.hpp
+++ b/src/rpp/rpp/operators/group_by.hpp
@@ -127,7 +127,7 @@ private:
 
         if (inserted)
         {
-            disposable->add(itr->second.get_disposable());
+            disposable->add(rpp::disposable_wrapper::from_weak(itr->second.get_disposable()));
             obs.on_next(rpp::grouped_observable_group_by<TKey, Type>{std::move(key), group_by_observable_strategy<Type>{itr->second, disposable}});
         }
 

--- a/src/tests/rpp/test_disposables.cpp
+++ b/src/tests/rpp/test_disposables.cpp
@@ -167,7 +167,10 @@ TEST_CASE("refcount disposable dispose underlying in case of reaching zero")
             disposables.push_back(refcount->add_ref());
 
         CHECK(!refcount->is_disposed());
-        refcount->dispose();
+
+        for (size_t i = 0; i < 10*count; ++i)
+            refcount->dispose();
+
         CHECK(refcount->is_disposed());
         CHECK(!underlying->is_disposed());
 

--- a/src/tests/rpp/test_disposables.cpp
+++ b/src/tests/rpp/test_disposables.cpp
@@ -162,18 +162,23 @@ TEST_CASE("refcount disposable dispose underlying in case of reaching zero")
     SECTION("add_ref prevents immediate disposing")
     {
         size_t count = 5;
+        std::vector<rpp::disposable_wrapper> disposables{};
         for (size_t i = 0; i < count; ++i)
-            refcount->add_ref();
+            disposables.push_back(refcount->add_ref());
 
-        for (size_t i = 0; i < count + 1; ++i)
+        CHECK(!refcount->is_disposed());
+        refcount->dispose();
+        CHECK(refcount->is_disposed());
+        CHECK(!underlying->is_disposed());
+
+        for(auto& d : disposables)
         {
             CHECK(!underlying->is_disposed());
-            CHECK(!refcount->is_disposed());
-
-            refcount->dispose();
+            CHECK(!d.is_disposed());
+            d.dispose();
+            CHECK(d.is_disposed());
         }
 
         CHECK(underlying->dispose_count == 1);
-        CHECK(refcount->is_disposed());
     }
 }

--- a/src/tests/rpp/test_group_by.cpp
+++ b/src/tests/rpp/test_group_by.cpp
@@ -12,8 +12,10 @@
 
 #include <rpp/operators/take.hpp>
 #include <rpp/operators/group_by.hpp>
+#include <rpp/operators/delay.hpp>
 #include <rpp/sources/create.hpp>
 #include <rpp/sources/just.hpp>
+#include <rpp/schedulers/immediate.hpp>
 
 #include "mock_observer.hpp"
 #include "rpp/disposables/composite_disposable.hpp"
@@ -190,7 +192,7 @@ TEST_CASE("group_by selectors affects types", "[group_by]")
     SECTION("subscribe on observable via group_by with identity key selector")
     {
         std::vector<int> keys{};
-        obs | rpp::ops::group_by(std::identity{}) 
+        obs | rpp::ops::group_by(std::identity{})
             | rpp::ops::subscribe([&](const auto& grouped)
         {
             keys.push_back(grouped.get_key());
@@ -204,7 +206,7 @@ TEST_CASE("group_by selectors affects types", "[group_by]")
     SECTION("subscribe on observable via group_by with value selector")
     {
         auto mock = mock_observer_strategy<std::string>{};
-        obs | rpp::ops::group_by(std::identity{}, [](int v){return std::to_string(v);}) 
+        obs | rpp::ops::group_by(std::identity{}, [](int v){return std::to_string(v);})
             | rpp::ops::subscribe([&](const auto& grouped)
         {
             grouped.subscribe(mock.get_observer());
@@ -225,7 +227,7 @@ TEST_CASE("group_by selectors affects types", "[group_by]")
                     [](int f, int s)
                     {
                         return f % 2 < s %2;
-                    }) 
+                    })
             | rpp::ops::subscribe([&](const auto& grouped)
         {
             keys.push_back(grouped.get_key());
@@ -240,7 +242,7 @@ TEST_CASE("group_by selectors affects types", "[group_by]")
 
     SECTION("subscribe on observable via group_by with key selector with exception")
     {
-        obs | rpp::ops::group_by([](int) -> int {throw std::runtime_error{""};}) 
+        obs | rpp::ops::group_by([](int) -> int {throw std::runtime_error{""};})
             | rpp::ops::subscribe(mock.get_observer());
         SECTION("on_error obtained once")
         {
@@ -252,7 +254,7 @@ TEST_CASE("group_by selectors affects types", "[group_by]")
 
     SECTION("subscribe on observable via group_by with value selector with exception")
     {
-        obs | rpp::ops::group_by(std::identity{}, [](int) -> int {throw std::runtime_error{""};}) 
+        obs | rpp::ops::group_by(std::identity{}, [](int) -> int {throw std::runtime_error{""};})
             | rpp::ops::subscribe(mock.get_observer());
         SECTION("on_error obtained once")
         {
@@ -261,4 +263,25 @@ TEST_CASE("group_by selectors affects types", "[group_by]")
             REQUIRE(mock.get_on_completed_count() == 0);
         }
     }
+}
+
+TEST_CASE("group_by's disposables tracks 1 dispose per call")
+{
+    auto mock_0 = mock_observer_strategy<int>{};
+    rpp::source::just(1, 2)
+    | rpp::ops::group_by([](int){return 0;})
+    | rpp::ops::subscribe([&](const auto& observable)
+    {
+        for(size_t i =0; i < 10;++i)
+        {
+            observable
+            | rpp::ops::take(1)
+            | rpp::ops::delay(std::chrono::seconds{0}, rpp::schedulers::immediate{})
+            | rpp::ops::subscribe([](int){});
+        }
+
+        observable.subscribe(mock_0.get_observer());
+    });
+
+    CHECK(mock_0.get_received_values() == std::vector{1,2});
 }

--- a/src/tests/rpp/test_group_by.cpp
+++ b/src/tests/rpp/test_group_by.cpp
@@ -146,7 +146,7 @@ TEST_CASE("group_by keeps subscription till anyone subscribed")
         REQUIRE(!d->is_disposed());
         REQUIRE(!observable_upstream->is_disposed());
     }
-    SECTION("diispose all")
+    SECTION("dispose all")
     {
         d->dispose();
         rpp::utils::for_each(disposables, std::mem_fn(&rpp::composite_disposable_wrapper::dispose));


### PR DESCRIPTION
Old version of refcount was incorrect due to upstream can be copied multiple times and dispose can be called multiple times, so, counter would be incorrect