### PR TITLE
Disambiguate tap operator

### DIFF
--- a/src/rpp/rpp/operators/fwd.hpp
+++ b/src/rpp/rpp/operators/fwd.hpp
@@ -156,6 +156,7 @@ namespace rpp::operators
     auto take_until(TObservable&& until_observable);
 
     template<std::invocable<const std::exception_ptr&> OnError = rpp::utils::empty_function_t<std::exception_ptr>>
+        requires utils::is_not_template_callable<OnError>
     auto tap(OnError&& on_error);
 
     template<std::invocable<> OnCompleted = rpp::utils::empty_function_t<>>
@@ -169,6 +170,7 @@ namespace rpp::operators
     template<typename OnNext                                       = rpp::utils::empty_function_any_t,
              std::invocable<const std::exception_ptr&> OnError     = rpp::utils::empty_function_t<std::exception_ptr>,
              std::invocable<>                          OnCompleted = rpp::utils::empty_function_t<>>
+        requires utils::is_not_template_callable<OnError>
     auto tap(OnNext&&      on_next      = {},
              OnError&&     on_error     = {},
              OnCompleted&& on_completed = {});

--- a/src/rpp/rpp/operators/tap.hpp
+++ b/src/rpp/rpp/operators/tap.hpp
@@ -90,6 +90,7 @@ namespace rpp::operators
      * @see https://reactivex.io/documentation/operators/do.html
      */
     template<std::invocable<const std::exception_ptr&> OnError /* = rpp::utils::empty_function_t<std::exception_ptr> */>
+        requires utils::is_not_template_callable<OnError>
     auto tap(OnError&& on_error)
     {
         using OnNext      = rpp::utils::empty_function_any_t;
@@ -156,6 +157,7 @@ namespace rpp::operators
     template<typename OnNext /* = rpp::utils::empty_function_any_t */,
              std::invocable<const std::exception_ptr&> OnError /* = rpp::utils::empty_function_t<std::exception_ptr> */,
              std::invocable<>                          OnCompleted /* = rpp::utils::empty_function_t<> */>
+        requires utils::is_not_template_callable<OnError>
     auto tap(OnNext&&      on_next /* = {} */,
              OnError&&     on_error /* = {} */,
              OnCompleted&& on_completed /* = {} */)

--- a/src/tests/rpp/test_tap.cpp
+++ b/src/tests/rpp/test_tap.cpp
@@ -77,7 +77,7 @@ TEMPLATE_TEST_CASE("tap observes emissions and doesn't modify them", "", rpp::me
 
         SECTION("pass on_next callback with auto argument")
         {
-            size_t on_next_invoked      = 0;
+            size_t on_next_invoked = 0;
 
             obs | rpp::ops::tap([&](const auto&) { ++on_next_invoked; })
                 | rpp::ops::subscribe(mock);

--- a/src/tests/rpp/test_tap.cpp
+++ b/src/tests/rpp/test_tap.cpp
@@ -74,6 +74,20 @@ TEMPLATE_TEST_CASE("tap observes emissions and doesn't modify them", "", rpp::me
             CHECK(on_next_invoked == mock.get_total_on_next_count());
             CHECK(on_completed_invoked == mock.get_on_completed_count());
         }
+
+        SECTION("pass on_next callback with auto argument")
+        {
+            size_t on_next_invoked      = 0;
+
+            obs | rpp::ops::tap([&](const auto&) { ++on_next_invoked; })
+                | rpp::ops::subscribe(mock);
+
+            CHECK(mock.get_received_values() == std::vector{1, 2, 3});
+            CHECK(mock.get_on_error_count() == 0);
+            CHECK(mock.get_on_completed_count() == 1);
+
+            CHECK(on_next_invoked == mock.get_total_on_next_count());
+        }
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for the `tap` function by ensuring the `OnError` parameter cannot be a template callable.
  
- **Bug Fixes**
	- Improved robustness of the `tap` operator, preventing misuse with inappropriate callable types.

- **Tests**
	- Added new test cases for the `tap` operator to verify its behavior with `on_next` callbacks, ensuring correct invocation and completion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->