### PR TITLE
Try limit grpc threads

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -355,7 +355,10 @@
     {
       "name": "ci-tests-debug",
       "inherits": ["ci-tests-base"],
-      "configuration": "Debug"
+      "configuration": "Debug",
+      "execution": {
+        "timeout": 120
+      }
     },
     {
       "name": "ci-sanitize",

--- a/src/tests/rppgrpc/test_async_client.cpp
+++ b/src/tests/rppgrpc/test_async_client.cpp
@@ -124,7 +124,7 @@ TEST_CASE("async client reactor")
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
             subj.get_observer().on_completed();
-    
+
             bidi_reactor->init();
 
             auto f = results.get_future();

--- a/src/tests/rppgrpc/test_async_client.cpp
+++ b/src/tests/rppgrpc/test_async_client.cpp
@@ -341,13 +341,14 @@ TEST_CASE("async client reactor")
                     results.set_value(reads);
                 });
 
-            write_reactor->init();
 
             subj.get_observer().on_next(1);
             subj.get_observer().on_next(2);
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
             subj.get_observer().on_completed();
+
+            write_reactor->init();
 
             auto f = results.get_future();
             REQUIRE(f.wait_for(std::chrono::seconds{1}) == std::future_status::ready);

--- a/src/tests/rppgrpc/test_async_client.cpp
+++ b/src/tests/rppgrpc/test_async_client.cpp
@@ -55,24 +55,18 @@ TEST_CASE("async client reactor")
         {
             REQUIRE_CALL(*mock_service, Bidirectional(trompeloeil::_, trompeloeil::_)).RETURN(grpc::Status::OK).IN_SEQUENCE(s);
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
-            auto       t    = std::thread{[&] {
-                bidi_reactor->init();
-            }};
+            bidi_reactor->init();
 
             wait(last);
-            t.join();
         }
 
         SECTION("error status - error")
         {
             REQUIRE_CALL(*mock_service, Bidirectional(trompeloeil::_, trompeloeil::_)).RETURN(grpc::Status::CANCELLED).IN_SEQUENCE(s);
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_error(trompeloeil::_)).IN_SEQUENCE(s);
-            auto       t    = std::thread{[&] {
-                bidi_reactor->init();
-            }};
+            bidi_reactor->init();
 
             wait(last);
-            t.join();
         }
 
         SECTION("manual server-side cancel")
@@ -83,14 +77,11 @@ TEST_CASE("async client reactor")
                     ctx.TryCancel();
                 });
 
-            auto t = std::thread{[&] {
-                bidi_reactor->init();
-            }};
+            bidi_reactor->init();
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_error(trompeloeil::_)).IN_SEQUENCE(s);
 
             wait(last);
-            t.join();
         }
 
         SECTION("manual client-side completion")
@@ -104,15 +95,12 @@ TEST_CASE("async client reactor")
                     }
                 });
 
-            auto t = std::thread{[&] {
-                bidi_reactor->init();
-            }};
+            bidi_reactor->init();
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
             subj.get_observer().on_completed();
 
             wait(last);
-            t.join();
         }
 
         SECTION("client-side write + completion")
@@ -130,9 +118,7 @@ TEST_CASE("async client reactor")
                     results.set_value(reads);
                 });
 
-            auto t = std::thread{[&] {
-                bidi_reactor->init();
-            }};
+            bidi_reactor->init();
 
             subj.get_observer().on_next(1);
             subj.get_observer().on_next(2);
@@ -145,7 +131,6 @@ TEST_CASE("async client reactor")
             CHECK(f.get() == std::vector<int>{1, 2});
 
             wait(last);
-            t.join();
         }
 
         SECTION("client-side read + completion")
@@ -161,9 +146,7 @@ TEST_CASE("async client reactor")
                         _2->Write(response);
                     }
                 });
-            auto t = std::thread{[&] {
-                bidi_reactor->init();
-            }};
+            bidi_reactor->init();
 
             REQUIRE_CALL(*out_mock, on_next_rvalue(1)).IN_SEQUENCE(s);
             REQUIRE_CALL(*out_mock, on_next_rvalue(2)).IN_SEQUENCE(s);
@@ -171,7 +154,6 @@ TEST_CASE("async client reactor")
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
 
             wait(last);
-            t.join();
         }
 
         SECTION("client-side read-write + completeion")
@@ -188,9 +170,7 @@ TEST_CASE("async client reactor")
                     }
                 });
 
-            auto t = std::thread{[&] {
-                bidi_reactor->init();
-            }};
+            bidi_reactor->init();
 
             REQUIRE_CALL(*out_mock, on_next_rvalue(10)).IN_SEQUENCE(s);
             subj.get_observer().on_next(1);
@@ -202,7 +182,6 @@ TEST_CASE("async client reactor")
             subj.get_observer().on_completed();
 
             wait(last);
-            t.join();
         }
     }
     SECTION("server-side")
@@ -217,12 +196,9 @@ TEST_CASE("async client reactor")
             stub->async()->ServerSide(&ctx, nullptr, read_reactor);
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_error(trompeloeil::_)).IN_SEQUENCE(s);
-            auto       t    = std::thread{[&] {
-                read_reactor->init();
-            }};
+            read_reactor->init();
 
             wait(last);
-            t.join();
         }
         SECTION("normal request")
         {
@@ -233,24 +209,18 @@ TEST_CASE("async client reactor")
             {
                 REQUIRE_CALL(*mock_service, ServerSide(trompeloeil::_, trompeloeil::_, trompeloeil::_)).RETURN(grpc::Status::OK).IN_SEQUENCE(s);
                 const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
-                auto       t    = std::thread{[&] {
-                    read_reactor->init();
-                }};
+                read_reactor->init();
 
                 wait(last);
-                t.join();
             }
 
             SECTION("error status - error")
             {
                 REQUIRE_CALL(*mock_service, ServerSide(trompeloeil::_, trompeloeil::_, trompeloeil::_)).RETURN(grpc::Status::CANCELLED).IN_SEQUENCE(s);
                 const auto last = NAMED_REQUIRE_CALL(*out_mock, on_error(trompeloeil::_)).IN_SEQUENCE(s);
-                auto       t    = std::thread{[&] {
-                    read_reactor->init();
-                }};
+                read_reactor->init();
 
                 wait(last);
-                t.join();
             }
 
             SECTION("manual server-side cancel")
@@ -261,14 +231,11 @@ TEST_CASE("async client reactor")
                         ctx.TryCancel();
                     });
 
-                auto t = std::thread{[&] {
-                    read_reactor->init();
-                }};
+                read_reactor->init();
 
                 const auto last = NAMED_REQUIRE_CALL(*out_mock, on_error(trompeloeil::_)).IN_SEQUENCE(s);
 
                 wait(last);
-                t.join();
             }
 
             SECTION("client-side read + completion")
@@ -284,9 +251,7 @@ TEST_CASE("async client reactor")
                             _3->Write(response);
                         }
                     });
-                auto t = std::thread{[&] {
-                    read_reactor->init();
-                }};
+                read_reactor->init();
 
                 REQUIRE_CALL(*out_mock, on_next_rvalue(1)).IN_SEQUENCE(s);
                 REQUIRE_CALL(*out_mock, on_next_rvalue(2)).IN_SEQUENCE(s);
@@ -294,7 +259,6 @@ TEST_CASE("async client reactor")
                 const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
 
                 wait(last);
-                t.join();
             }
         }
     }
@@ -312,24 +276,18 @@ TEST_CASE("async client reactor")
         {
             REQUIRE_CALL(*mock_service, ClientSide(trompeloeil::_, trompeloeil::_, trompeloeil::_)).RETURN(grpc::Status::OK).IN_SEQUENCE(s);
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
-            auto       t    = std::thread{[&] {
-                write_reactor->init();
-            }};
+            write_reactor->init();
 
             wait(last);
-            t.join();
         }
 
         SECTION("error status - error")
         {
             REQUIRE_CALL(*mock_service, ClientSide(trompeloeil::_, trompeloeil::_, trompeloeil::_)).RETURN(grpc::Status::CANCELLED).IN_SEQUENCE(s);
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_error(trompeloeil::_)).IN_SEQUENCE(s);
-            auto       t    = std::thread{[&] {
-                write_reactor->init();
-            }};
+            write_reactor->init();
 
             wait(last);
-            t.join();
         }
 
         SECTION("manual server-side cancel")
@@ -340,14 +298,11 @@ TEST_CASE("async client reactor")
                     ctx.TryCancel();
                 });
 
-            auto t = std::thread{[&] {
-                write_reactor->init();
-            }};
+            write_reactor->init();
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_error(trompeloeil::_)).IN_SEQUENCE(s);
 
             wait(last);
-            t.join();
         }
 
         SECTION("manual client-side completion")
@@ -361,15 +316,12 @@ TEST_CASE("async client reactor")
                     }
                 });
 
-            auto t = std::thread{[&] {
-                write_reactor->init();
-            }};
+            write_reactor->init();
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
             subj.get_observer().on_completed();
 
             wait(last);
-            t.join();
         }
 
         SECTION("client-side write + completion")
@@ -387,9 +339,7 @@ TEST_CASE("async client reactor")
                     results.set_value(reads);
                 });
 
-            auto t = std::thread{[&] {
-                write_reactor->init();
-            }};
+            write_reactor->init();
 
             subj.get_observer().on_next(1);
             subj.get_observer().on_next(2);
@@ -402,7 +352,6 @@ TEST_CASE("async client reactor")
             CHECK(f.get() == std::vector<int>{1, 2});
 
             wait(last);
-            t.join();
         }
     }
     server->Shutdown();

--- a/src/tests/rppgrpc/test_async_client.cpp
+++ b/src/tests/rppgrpc/test_async_client.cpp
@@ -171,7 +171,6 @@ TEST_CASE("async client reactor")
                     }
                 });
 
-            bidi_reactor->init();
 
             REQUIRE_CALL(*out_mock, on_next_rvalue(10)).IN_SEQUENCE(s);
             subj.get_observer().on_next(1);
@@ -181,6 +180,8 @@ TEST_CASE("async client reactor")
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
             subj.get_observer().on_completed();
+
+            bidi_reactor->init();
 
             wait(last);
         }

--- a/src/tests/rppgrpc/test_async_client.cpp
+++ b/src/tests/rppgrpc/test_async_client.cpp
@@ -118,13 +118,14 @@ TEST_CASE("async client reactor")
                     results.set_value(reads);
                 });
 
-            bidi_reactor->init();
 
             subj.get_observer().on_next(1);
             subj.get_observer().on_next(2);
 
             const auto last = NAMED_REQUIRE_CALL(*out_mock, on_completed()).IN_SEQUENCE(s);
             subj.get_observer().on_completed();
+    
+            bidi_reactor->init();
 
             auto f = results.get_future();
             REQUIRE(f.wait_for(std::chrono::seconds{1}) == std::future_status::ready);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Simplified test cases for the asynchronous client and server by removing unnecessary threading, enhancing clarity and maintainability without affecting functionality.
- **Tests**
	- Improved readability and efficiency of test cases while ensuring synchronization with mock service responses remains intact.
- **New Features**
	- Introduced a timeout setting for the `ci-tests-debug` configuration, enhancing execution control for long-running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->