### PR TITLE
Fix disposables issue

### DIFF
--- a/src/rpp/rpp/disposables/refcount_disposable.hpp
+++ b/src/rpp/rpp/disposables/refcount_disposable.hpp
@@ -56,10 +56,10 @@ namespace rpp
 
         enum class Mode : bool
         {
-            Weak,
-            Strong
+            WeakRefStrongSource,
+            StrongRefRefSource
         };
-        composite_disposable_wrapper add_ref(Mode mode = Mode::Weak);
+        composite_disposable_wrapper add_ref(Mode mode = Mode::WeakRefStrongSource);
 
     private:
         std::atomic<size_t>     m_refcount{0};
@@ -107,8 +107,8 @@ namespace rpp
             // just need atomicity, not guarding anything
             if (m_refcount.compare_exchange_strong(current_value, current_value + 1, std::memory_order::seq_cst))
             {
-                auto inner = composite_disposable_wrapper::make<details::refocunt_disposable_inner>(wrapper_from_this());
-                add(mode == Mode::Weak ? inner.as_weak() : inner);
+                auto inner = composite_disposable_wrapper::make<details::refocunt_disposable_inner>(mode == Mode::WeakRefStrongSource ? wrapper_from_this() : wrapper_from_this().as_weak());
+                add(mode == Mode::WeakRefStrongSource ? inner.as_weak() : inner);
                 return inner;
             }
         }

--- a/src/rpp/rpp/operators/combine_latest.hpp
+++ b/src/rpp/rpp/operators/combine_latest.hpp
@@ -19,11 +19,11 @@
 namespace rpp::operators::details
 {
     template<rpp::constraint::observer Observer, typename TSelector, rpp::constraint::decayed_type... Args>
-    class combine_latest_disposable final : public combining_disposable<Observer, Args...>
+    class combine_latest_state final : public combining_state<Observer>
     {
     public:
-        explicit combine_latest_disposable(Observer&& observer, const TSelector& selector)
-            : combining_disposable<Observer, Args...>(std::move(observer))
+        explicit combine_latest_state(Observer&& observer, const TSelector& selector)
+            : combining_state<Observer>(std::move(observer), sizeof...(Args))
             , m_selector(selector)
         {
         }
@@ -40,23 +40,23 @@ namespace rpp::operators::details
 
     template<size_t I, rpp::constraint::observer Observer, typename TSelector, rpp::constraint::decayed_type... Args>
     struct combine_latest_observer_strategy final
-        : public combining_observer_strategy<combine_latest_disposable<Observer, TSelector, Args...>>
+        : public combining_observer_strategy<combine_latest_state<Observer, TSelector, Args...>>
     {
-        using combining_observer_strategy<combine_latest_disposable<Observer, TSelector, Args...>>::disposable;
+        using combining_observer_strategy<combine_latest_state<Observer, TSelector, Args...>>::state;
 
         template<typename T>
         void on_next(T&& v) const
         {
             // mutex need to be locked during changing of values, generating new values and sending of new values due to we can't update value while we are sending old one
-            const auto observer = disposable->get_observer_under_lock();
-            disposable->get_values().template get<I>().emplace(std::forward<T>(v));
+            const auto observer = state->get_observer_under_lock();
+            state->get_values().template get<I>().emplace(std::forward<T>(v));
 
-            disposable->get_values().apply(&apply_impl<decltype(disposable)>, disposable, observer);
+            state->get_values().apply(&apply_impl<decltype(state)>, state, observer);
         }
 
     private:
-        template<typename TDisposable>
-        static void apply_impl(const TDisposable& disposable, const rpp::utils::pointer_under_lock<Observer>& observer, const std::optional<Args>&... vals)
+        template<typename TState>
+        static void apply_impl(const TState& disposable, const rpp::utils::pointer_under_lock<Observer>& observer, const std::optional<Args>&... vals)
         {
             if ((vals.has_value() && ...))
                 observer->on_next(disposable->get_selector()(vals.value()...));
@@ -64,7 +64,7 @@ namespace rpp::operators::details
     };
 
     template<typename TSelector, rpp::constraint::observable... TObservables>
-    struct combine_latest_t : public combining_operator_t<combine_latest_disposable, combine_latest_observer_strategy, TSelector, TObservables...>
+    struct combine_latest_t : public combining_operator_t<combine_latest_state, combine_latest_observer_strategy, TSelector, TObservables...>
     {
     };
 } // namespace rpp::operators::details

--- a/src/rpp/rpp/operators/concat.hpp
+++ b/src/rpp/rpp/operators/concat.hpp
@@ -118,7 +118,7 @@ namespace rpp::operators::details
         }
 
         concat_observer_strategy_base(std::shared_ptr<concat_state_t<TObservable, TObserver>> state)
-            : concat_observer_strategy_base{state, state->get_disposable()->add_ref(refcount_disposable::Mode::Strong)}
+            : concat_observer_strategy_base{state, state->get_disposable()->add_ref(refcount_disposable::Mode::StrongRefRefSource)}
         {
         }
 
@@ -177,7 +177,7 @@ namespace rpp::operators::details
         {
             ConcatStage current = ConcatStage::None;
             if (base::state->stage().compare_exchange_strong(current, ConcatStage::Draining, std::memory_order::seq_cst))
-                base::state->handle_observable(std::forward<T>(v), base::state->get_disposable()->add_ref(refcount_disposable::Mode::Strong));
+                base::state->handle_observable(std::forward<T>(v), base::state->get_disposable()->add_ref(refcount_disposable::Mode::StrongRefRefSource));
             else
                 base::state->get_queue()->push(std::forward<T>(v));
         }

--- a/src/rpp/rpp/operators/concat.hpp
+++ b/src/rpp/rpp/operators/concat.hpp
@@ -34,29 +34,33 @@ namespace rpp::operators::details
     };
 
     template<rpp::constraint::observable TObservable, rpp::constraint::observer TObserver>
-    class concat_state_t final : public rpp::refcount_disposable
+    class concat_state_t final : public std::enable_shared_from_this<concat_state_t<TObservable, TObserver>>
     {
     public:
         concat_state_t(TObserver&& observer)
             : m_observer{std::move(observer)}
         {
+            const auto d = disposable_wrapper_impl<refcount_disposable>::make();
+            m_disposable = d.lock();
+            get_observer()->set_upstream(d);
         }
 
         rpp::utils::pointer_under_lock<TObserver>               get_observer() { return m_observer; }
         rpp::utils::pointer_under_lock<std::queue<TObservable>> get_queue() { return m_queue; }
+        const std::shared_ptr<refcount_disposable>& get_disposable() const { return m_disposable; }
 
         std::atomic<ConcatStage>& stage() { return m_stage; }
 
         void drain(rpp::composite_disposable_wrapper refcounted)
         {
-            while (!is_disposed())
+            while (!m_disposable->is_disposed())
             {
                 const auto observable = get_observable();
                 if (!observable)
                 {
                     stage().store(ConcatStage::None, std::memory_order::relaxed);
                     refcounted.dispose();
-                    if (is_disposed())
+                    if (m_disposable->is_disposed())
                         get_observer()->on_completed();
                     return;
                 }
@@ -74,12 +78,13 @@ namespace rpp::operators::details
             drain(refcounted);
         }
 
+
     private:
         bool handle_observable_impl(const rpp::constraint::decayed_same_as<TObservable> auto& observable, rpp::composite_disposable_wrapper refcounted)
         {
             stage().store(ConcatStage::Draining, std::memory_order::relaxed);
             refcounted.clear();
-            observable.subscribe(concat_inner_observer_strategy<TObservable, TObserver>{disposable_wrapper_impl<concat_state_t>{wrapper_from_this()}.lock(), std::move(refcounted)});
+            observable.subscribe(concat_inner_observer_strategy<TObservable, TObserver>{this->shared_from_this(), std::move(refcounted)});
 
             ConcatStage current = ConcatStage::Draining;
             return stage().compare_exchange_strong(current, ConcatStage::Processing, std::memory_order::seq_cst);
@@ -97,6 +102,7 @@ namespace rpp::operators::details
         }
 
     private:
+        std::shared_ptr<refcount_disposable>                  m_disposable{};
         rpp::utils::value_with_mutex<TObserver>               m_observer;
         rpp::utils::value_with_mutex<std::queue<TObservable>> m_queue;
         std::atomic<ConcatStage>                              m_stage{};
@@ -112,7 +118,7 @@ namespace rpp::operators::details
         }
 
         concat_observer_strategy_base(std::shared_ptr<concat_state_t<TObservable, TObserver>> state)
-            : concat_observer_strategy_base{state, state->add_ref()}
+            : concat_observer_strategy_base{state, state->get_disposable()->add_ref(refcount_disposable::Mode::Strong)}
         {
         }
 
@@ -122,7 +128,7 @@ namespace rpp::operators::details
         void on_error(const std::exception_ptr& err) const
         {
             state->get_observer()->on_error(err);
-            state->dispose();
+            state->get_disposable()->dispose();
         }
 
         void set_upstream(const disposable_wrapper& d) const { refcounted.add(d); }
@@ -162,7 +168,7 @@ namespace rpp::operators::details
         using preferred_disposable_strategy = rpp::details::observers::none_disposable_strategy;
 
         concat_observer_strategy(TObserver&& observer)
-            : base{init_state(std::move(observer))}
+            : base{std::make_shared<concat_state_t<TObservable, TObserver>>(std::move(observer))}
         {
         }
 
@@ -171,7 +177,7 @@ namespace rpp::operators::details
         {
             ConcatStage current = ConcatStage::None;
             if (base::state->stage().compare_exchange_strong(current, ConcatStage::Draining, std::memory_order::seq_cst))
-                base::state->handle_observable(std::forward<T>(v), base::state->add_ref());
+                base::state->handle_observable(std::forward<T>(v), base::state->get_disposable()->add_ref(refcount_disposable::Mode::Strong));
             else
                 base::state->get_queue()->push(std::forward<T>(v));
         }
@@ -179,18 +185,8 @@ namespace rpp::operators::details
         void on_completed() const
         {
             base::refcounted.dispose();
-            if (base::state->is_disposed())
+            if (base::state->get_disposable()->is_disposed())
                 base::state->get_observer()->on_completed();
-        }
-
-
-    private:
-        static std::shared_ptr<concat_state_t<TObservable, TObserver>> init_state(TObserver&& observer)
-        {
-            const auto d   = disposable_wrapper_impl<concat_state_t<TObservable, TObserver>>::make(std::move(observer));
-            auto       ptr = d.lock();
-            ptr->get_observer()->set_upstream(d.as_weak());
-            return ptr;
         }
     };
 

--- a/src/rpp/rpp/operators/concat.hpp
+++ b/src/rpp/rpp/operators/concat.hpp
@@ -47,7 +47,7 @@ namespace rpp::operators::details
 
         rpp::utils::pointer_under_lock<TObserver>               get_observer() { return m_observer; }
         rpp::utils::pointer_under_lock<std::queue<TObservable>> get_queue() { return m_queue; }
-        const std::shared_ptr<refcount_disposable>& get_disposable() const { return m_disposable; }
+        const std::shared_ptr<refcount_disposable>&             get_disposable() const { return m_disposable; }
 
         std::atomic<ConcatStage>& stage() { return m_stage; }
 

--- a/src/rpp/rpp/operators/debounce.hpp
+++ b/src/rpp/rpp/operators/debounce.hpp
@@ -138,7 +138,7 @@ namespace rpp::operators::details
         void on_completed() const noexcept
         {
             const auto observer = state->get_observer_under_lock();
-            if (const auto value    = state->extract_value())
+            if (const auto value = state->extract_value())
                 observer->on_next(std::move(value).value());
             observer->on_completed();
         }
@@ -162,7 +162,7 @@ namespace rpp::operators::details
         template<rpp::constraint::decayed_type Type, rpp::constraint::observer Observer>
         auto lift(Observer&& observer) const
         {
-            using worker_t  = rpp::schedulers::utils::get_worker_t<Scheduler>;
+            using worker_t = rpp::schedulers::utils::get_worker_t<Scheduler>;
 
             auto ptr = std::make_shared<debounce_state<std::decay_t<Observer>, worker_t>>(std::forward<Observer>(observer), scheduler.create_worker(), duration);
             return rpp::observer<Type, debounce_observer_strategy<std::decay_t<Observer>, worker_t>>{std::move(ptr)};

--- a/src/rpp/rpp/operators/debounce.hpp
+++ b/src/rpp/rpp/operators/debounce.hpp
@@ -12,7 +12,6 @@
 
 #include <rpp/operators/fwd.hpp>
 
-#include <rpp/disposables/composite_disposable.hpp>
 #include <rpp/operators/details/strategy.hpp>
 #include <rpp/utils/utils.hpp>
 

--- a/src/rpp/rpp/operators/delay.hpp
+++ b/src/rpp/rpp/operators/delay.hpp
@@ -180,7 +180,7 @@ namespace rpp::operators::details
         template<rpp::constraint::decayed_type Type, rpp::constraint::observer Observer>
         auto lift(Observer&& observer) const
         {
-            using worker_t  = rpp::schedulers::utils::get_worker_t<Scheduler>;
+            using worker_t = rpp::schedulers::utils::get_worker_t<Scheduler>;
 
             auto state = std::make_shared<delay_state<std::decay_t<Observer>, worker_t>>(std::forward<Observer>(observer), scheduler.create_worker(), duration);
             return rpp::observer<Type, delay_observer_strategy<std::decay_t<Observer>, worker_t, ClearOnError>>{std::move(state)};

--- a/src/rpp/rpp/operators/delay.hpp
+++ b/src/rpp/rpp/operators/delay.hpp
@@ -13,7 +13,6 @@
 #include <rpp/operators/fwd.hpp>
 
 #include <rpp/defs.hpp>
-#include <rpp/disposables/composite_disposable.hpp>
 #include <rpp/operators/details/strategy.hpp>
 
 #include <mutex>

--- a/src/rpp/rpp/operators/details/combining_strategy.hpp
+++ b/src/rpp/rpp/operators/details/combining_strategy.hpp
@@ -13,7 +13,6 @@
 #include <rpp/operators/fwd.hpp>
 
 #include <rpp/defs.hpp>
-#include <rpp/disposables/composite_disposable.hpp>
 #include <rpp/operators/details/strategy.hpp>
 #include <rpp/schedulers/current_thread.hpp>
 #include <rpp/utils/utils.hpp>

--- a/src/rpp/rpp/operators/details/combining_strategy.hpp
+++ b/src/rpp/rpp/operators/details/combining_strategy.hpp
@@ -22,12 +22,13 @@
 
 namespace rpp::operators::details
 {
-    template<rpp::constraint::observer Observer, rpp::constraint::decayed_type... Args>
-    class combining_disposable : public composite_disposable
+    template<rpp::constraint::observer Observer>
+    class combining_state
     {
     public:
-        explicit combining_disposable(Observer&& observer)
+        explicit combining_state(Observer&& observer, size_t on_completed_needed)
             : m_observer_with_mutex{std::move(observer)}
+            , m_on_completed_needed{on_completed_needed}
         {
         }
 
@@ -42,41 +43,37 @@ namespace rpp::operators::details
     private:
         rpp::utils::value_with_mutex<Observer> m_observer_with_mutex{};
 
-        std::atomic_size_t m_on_completed_needed{sizeof...(Args)};
+        std::atomic_size_t m_on_completed_needed;
     };
 
-    template<typename TDisposable>
+    template<typename TState>
     struct combining_observer_strategy
     {
-        std::shared_ptr<TDisposable> disposable{};
+        std::shared_ptr<TState> state{};
 
         void set_upstream(const rpp::disposable_wrapper& d) const
         {
-            disposable->add(d);
+            state->get_observer_under_lock()->set_upstream(d);
         }
 
         bool is_disposed() const
         {
-            return disposable->is_disposed();
+            return state->get_observer_under_lock()->is_disposed();
         }
 
         void on_error(const std::exception_ptr& err) const
         {
-            disposable->get_observer_under_lock()->on_error(err);
-            disposable->dispose();
+            state->get_observer_under_lock()->on_error(err);
         }
 
         void on_completed() const
         {
-            if (disposable->decrement_on_completed())
-            {
-                disposable->get_observer_under_lock()->on_completed();
-                disposable->dispose();
-            }
+            if (state->decrement_on_completed())
+                state->get_observer_under_lock()->on_completed();
         }
     };
 
-    template<template<typename...> typename TDisposable, template<auto, typename...> typename TStrategy, typename TSelector, rpp::constraint::observable... TObservables>
+    template<template<typename...> typename TState, template<auto, typename...> typename TStrategy, typename TSelector, rpp::constraint::observable... TObservables>
     struct combining_operator_t
     {
         RPP_NO_UNIQUE_ADDRESS rpp::utils::tuple<TObservables...> observables;
@@ -93,7 +90,7 @@ namespace rpp::operators::details
         };
 
         template<rpp::details::observables::constraint::disposable_strategy Prev>
-        using updated_disposable_strategy = rpp::details::observables::fixed_disposable_strategy_selector<1>;
+        using updated_disposable_strategy = ::rpp::details::observables::default_disposable_strategy_selector; // TODO: sum of Prev + TObservables
 
         template<rpp::constraint::decayed_type Type, rpp::constraint::observer Observer>
         auto lift(Observer&& observer) const
@@ -105,20 +102,18 @@ namespace rpp::operators::details
         template<rpp::constraint::decayed_type Type, rpp::constraint::observer Observer>
         static auto subscribe_impl(Observer&& observer, const TSelector& selector, const TObservables&... observables)
         {
-            using Disposable = TDisposable<Observer, TSelector, Type, rpp::utils::extract_observable_type_t<TObservables>...>;
+            using State = TState<Observer, TSelector, Type, rpp::utils::extract_observable_type_t<TObservables>...>;
 
-            const auto disposable = disposable_wrapper_impl<Disposable>::make(std::forward<Observer>(observer), selector);
-            auto       locked     = disposable.lock();
-            locked->get_observer_under_lock()->set_upstream(disposable.as_weak());
-            subscribe<std::decay_t<Type>>(locked, std::index_sequence_for<TObservables...>{}, observables...);
+            const auto state = std::make_shared<State>(std::forward<Observer>(observer), selector);
+            subscribe<std::decay_t<Type>>(state, std::index_sequence_for<TObservables...>{}, observables...);
 
-            return rpp::observer<Type, TStrategy<0, std::decay_t<Observer>, TSelector, Type, rpp::utils::extract_observable_type_t<TObservables>...>>{std::move(locked)};
+            return rpp::observer<Type, TStrategy<0, std::decay_t<Observer>, TSelector, Type, rpp::utils::extract_observable_type_t<TObservables>...>>{std::move(state)};
         }
 
         template<typename ExpectedValue, rpp::constraint::observer Observer, size_t... I>
-        static void subscribe(const std::shared_ptr<TDisposable<Observer, TSelector, ExpectedValue, rpp::utils::extract_observable_type_t<TObservables>...>>& disposable, std::index_sequence<I...>, const TObservables&... observables)
+        static void subscribe(const std::shared_ptr<TState<Observer, TSelector, ExpectedValue, rpp::utils::extract_observable_type_t<TObservables>...>>& state, std::index_sequence<I...>, const TObservables&... observables)
         {
-            (..., observables.subscribe(rpp::observer<rpp::utils::extract_observable_type_t<TObservables>, TStrategy<I + 1, Observer, TSelector, ExpectedValue, rpp::utils::extract_observable_type_t<TObservables>...>>{disposable}));
+            (..., observables.subscribe(rpp::observer<rpp::utils::extract_observable_type_t<TObservables>, TStrategy<I + 1, Observer, TSelector, ExpectedValue, rpp::utils::extract_observable_type_t<TObservables>...>>{state}));
         }
     };
 } // namespace rpp::operators::details

--- a/src/rpp/rpp/operators/merge.hpp
+++ b/src/rpp/rpp/operators/merge.hpp
@@ -93,7 +93,7 @@ namespace rpp::operators::details
         }
 
     protected:
-        std::shared_ptr<merge_state<TObserver>> m_state;
+        std::shared_ptr<merge_state<TObserver>>      m_state;
         mutable std::vector<rpp::disposable_wrapper> m_disposables{};
     };
 

--- a/src/rpp/rpp/operators/merge.hpp
+++ b/src/rpp/rpp/operators/merge.hpp
@@ -13,7 +13,6 @@
 #include <rpp/operators/fwd.hpp>
 
 #include <rpp/defs.hpp>
-#include <rpp/disposables/composite_disposable.hpp>
 #include <rpp/operators/details/strategy.hpp>
 #include <rpp/schedulers/current_thread.hpp>
 #include <rpp/utils/tuple.hpp>
@@ -24,12 +23,13 @@
 namespace rpp::operators::details
 {
     template<rpp::constraint::observer TObserver>
-    class merge_disposable final : public composite_disposable
+    class merge_state final
     {
     public:
-        merge_disposable(TObserver&& observer)
+        merge_state(TObserver&& observer)
             : m_observer(std::move(observer))
         {
+            get_observer_under_lock()->set_upstream(m_disposable);
         }
 
         // just need atomicity, not guarding anything
@@ -40,56 +40,60 @@ namespace rpp::operators::details
 
         rpp::utils::pointer_under_lock<TObserver> get_observer_under_lock() { return m_observer; }
 
+        const rpp::composite_disposable_wrapper& get_disposable() const { return m_disposable; }
+
     private:
         rpp::utils::value_with_mutex<TObserver> m_observer{};
+        rpp::composite_disposable_wrapper       m_disposable = composite_disposable_wrapper::make();
         std::atomic_size_t                      m_on_completed_needed{1};
     };
 
     template<rpp::constraint::observer TObserver>
     struct merge_observer_base_strategy
     {
-        merge_observer_base_strategy(std::shared_ptr<merge_disposable<TObserver>>&& disposable)
-            : m_disposable{std::move(disposable)}
+        merge_observer_base_strategy(std::shared_ptr<merge_state<TObserver>>&& state)
+            : m_state{std::move(state)}
         {
         }
 
-        merge_observer_base_strategy(const std::shared_ptr<merge_disposable<TObserver>>& disposable)
-            : m_disposable{disposable}
+        merge_observer_base_strategy(const std::shared_ptr<merge_state<TObserver>>& state)
+            : m_state{state}
         {
         }
 
         void set_upstream(const rpp::disposable_wrapper& d) const
         {
-            m_disposable->add(d);
+            m_state->get_disposable().add(d);
             m_disposables.push_back(d);
         }
 
         bool is_disposed() const
         {
-            return m_disposable->is_disposed();
+            return m_state->get_observer_under_lock()->is_disposed();
         }
 
         void on_error(const std::exception_ptr& err) const
         {
-            m_disposable->get_observer_under_lock()->on_error(err);
-            m_disposable->dispose();
+            m_state->get_observer_under_lock()->on_error(err);
         }
 
         void on_completed() const
         {
-            if (m_disposable->decrement_on_completed())
+            if (m_state->decrement_on_completed())
+            {
+                m_state->get_observer_under_lock()->on_completed();
+            }
+            else
             {
                 for (const auto& v : m_disposables)
                 {
-                    m_disposable->remove(v);
+                    m_state->get_disposable().remove(v);
                 }
-                m_disposable->get_observer_under_lock()->on_completed();
-                m_disposable->dispose();
             }
         }
 
     protected:
-        std::shared_ptr<merge_disposable<TObserver>> m_disposable;
+        std::shared_ptr<merge_state<TObserver>> m_state;
         mutable std::vector<rpp::disposable_wrapper> m_disposables{};
     };
 
@@ -101,7 +105,7 @@ namespace rpp::operators::details
         template<typename T>
         void on_next(T&& v) const
         {
-            merge_observer_base_strategy<TObserver>::m_disposable->get_observer_under_lock()->on_next(std::forward<T>(v));
+            merge_observer_base_strategy<TObserver>::m_state->get_observer_under_lock()->on_next(std::forward<T>(v));
         }
     };
 
@@ -110,24 +114,15 @@ namespace rpp::operators::details
     {
     public:
         explicit merge_observer_strategy(TObserver&& observer)
-            : merge_observer_base_strategy<TObserver>{init_state(std::move(observer))}
+            : merge_observer_base_strategy<TObserver>{std::make_shared<merge_state<TObserver>>(std::move(observer))}
         {
         }
 
         template<typename T>
         void on_next(T&& v) const
         {
-            merge_observer_base_strategy<TObserver>::m_disposable->increment_on_completed();
-            std::forward<T>(v).subscribe(rpp::observer<rpp::utils::extract_observer_type_t<TObserver>, merge_observer_inner_strategy<TObserver>>{merge_observer_inner_strategy<TObserver>{merge_observer_base_strategy<TObserver>::m_disposable}});
-        }
-
-    private:
-        static std::shared_ptr<merge_disposable<TObserver>> init_state(TObserver&& observer)
-        {
-            const auto d   = disposable_wrapper_impl<merge_disposable<TObserver>>::make(std::move(observer));
-            auto       ptr = d.lock();
-            ptr->get_observer_under_lock()->set_upstream(d.as_weak());
-            return ptr;
+            merge_observer_base_strategy<TObserver>::m_state->increment_on_completed();
+            std::forward<T>(v).subscribe(rpp::observer<rpp::utils::extract_observer_type_t<TObserver>, merge_observer_inner_strategy<TObserver>>{merge_observer_inner_strategy<TObserver>{merge_observer_base_strategy<TObserver>::m_state}});
         }
     };
 

--- a/src/rpp/rpp/operators/on_error_resume_next.hpp
+++ b/src/rpp/rpp/operators/on_error_resume_next.hpp
@@ -18,18 +18,6 @@
 namespace rpp::operators::details
 {
     template<rpp::constraint::observer TObserver>
-    struct on_error_resume_next_disposable final : public rpp::composite_disposable
-    {
-        on_error_resume_next_disposable(TObserver&& observer)
-            : rpp::composite_disposable{}
-            , observer(std::move(observer))
-        {
-        }
-
-        RPP_NO_UNIQUE_ADDRESS TObserver observer;
-    };
-
-    template<rpp::constraint::observer TObserver>
     struct on_error_resume_next_inner_observer_strategy
     {
         using preferred_disposable_strategy = rpp::details::observers::none_disposable_strategy;
@@ -64,53 +52,43 @@ namespace rpp::operators::details
         using preferred_disposable_strategy = rpp::details::observers::none_disposable_strategy;
 
         on_error_resume_next_observer_strategy(TObserver&& observer, const Selector& selector)
-            : state{init_state(std::move(observer))}
+            : state{std::make_shared<TObserver>(std::move(observer))}
             , selector{selector}
         {
         }
 
-        std::shared_ptr<on_error_resume_next_disposable<TObserver>> state;
-        RPP_NO_UNIQUE_ADDRESS Selector                              selector;
+        std::shared_ptr<TObserver>     state;
+        RPP_NO_UNIQUE_ADDRESS Selector selector;
 
         template<typename T>
         void on_next(T&& v) const
         {
-            state->observer.on_next(std::forward<T>(v));
+            state->on_next(std::forward<T>(v));
         }
 
         void on_error(const std::exception_ptr& err) const
         {
             try
             {
-                selector(err).subscribe(on_error_resume_next_inner_observer_strategy<TObserver>{std::shared_ptr<TObserver>(state, &state->observer)});
+                selector(err).subscribe(on_error_resume_next_inner_observer_strategy<TObserver>{state});
             }
             catch (...)
             {
-                state->observer.on_error(std::current_exception());
+                state->on_error(std::current_exception());
             }
-            state->dispose();
         }
 
         void on_completed() const
         {
-            state->observer.on_completed();
-            state->dispose();
+            state->on_completed();
         }
 
         void set_upstream(const disposable_wrapper& d) const
         {
-            state->add(d);
+            state->set_upstream(d);
         }
 
         bool is_disposed() const { return state->is_disposed(); }
-
-        static std::shared_ptr<on_error_resume_next_disposable<TObserver>> init_state(TObserver&& observer)
-        {
-            const auto d   = disposable_wrapper_impl<on_error_resume_next_disposable<TObserver>>::make(std::move(observer));
-            auto       ptr = d.lock();
-            ptr->observer.set_upstream(d.as_weak());
-            return ptr;
-        }
     };
 
     template<rpp::constraint::decayed_type Selector>
@@ -135,7 +113,7 @@ namespace rpp::operators::details
         };
 
         template<rpp::details::observables::constraint::disposable_strategy Prev>
-        using updated_disposable_strategy = rpp::details::observables::atomic_dynamic_disposable_strategy_selector<1>;
+        using updated_disposable_strategy = rpp::details::observables::default_disposable_strategy_selector;
     };
 } // namespace rpp::operators::details
 

--- a/src/rpp/rpp/operators/retry.hpp
+++ b/src/rpp/rpp/operators/retry.hpp
@@ -126,7 +126,7 @@ namespace rpp::operators::details
         template<rpp::constraint::observer TObserver, typename TObservable>
         void subscribe(TObserver&& observer, TObservable&& observble) const
         {
-            const auto ptr   = std::make_shared<retry_state_t<std::decay_t<TObserver>, std::decay_t<TObservable>>>(std::forward<TObserver>(observer), std::forward<TObservable>(observble), count ? count.value() + 1 : count);
+            const auto ptr = std::make_shared<retry_state_t<std::decay_t<TObserver>, std::decay_t<TObservable>>>(std::forward<TObserver>(observer), std::forward<TObservable>(observble), count ? count.value() + 1 : count);
             drain(ptr);
         }
     };

--- a/src/rpp/rpp/operators/retry_when.hpp
+++ b/src/rpp/rpp/operators/retry_when.hpp
@@ -40,7 +40,6 @@ namespace rpp::operators::details
         RPP_NO_UNIQUE_ADDRESS TNotifier   notifier;
 
         rpp::composite_disposable_wrapper disposable = composite_disposable_wrapper::make();
-
     };
 
     template<rpp::constraint::observer TObserver, typename TObservable, typename TNotifier>

--- a/src/rpp/rpp/operators/retry_when.hpp
+++ b/src/rpp/rpp/operators/retry_when.hpp
@@ -23,13 +23,14 @@ namespace rpp::operators::details
     template<rpp::constraint::observer TObserver,
              typename TObservable,
              typename TNotifier>
-    struct retry_when_state final : public rpp::composite_disposable
+    struct retry_when_state final
     {
-        retry_when_state(TObserver&& observer, const TObservable& observable, const TNotifier& notifier)
-            : observer(std::move(observer))
+        retry_when_state(TObserver&& in_observer, const TObservable& observable, const TNotifier& notifier)
+            : observer(std::move(in_observer))
             , observable(observable)
             , notifier(notifier)
         {
+            observer.set_upstream(disposable);
         }
 
         std::atomic_bool is_inside_drain{};
@@ -37,6 +38,9 @@ namespace rpp::operators::details
         RPP_NO_UNIQUE_ADDRESS TObserver   observer;
         RPP_NO_UNIQUE_ADDRESS TObservable observable;
         RPP_NO_UNIQUE_ADDRESS TNotifier   notifier;
+
+        rpp::composite_disposable_wrapper disposable = composite_disposable_wrapper::make();
+
     };
 
     template<rpp::constraint::observer TObserver, typename TObservable, typename TNotifier>
@@ -56,7 +60,7 @@ namespace rpp::operators::details
         void on_next(T&&) const
         {
             locally_disposed = true;
-            state->clear();
+            state->disposable.clear();
 
             if (state->is_inside_drain.exchange(false, std::memory_order::seq_cst))
                 return;
@@ -76,9 +80,9 @@ namespace rpp::operators::details
             state->observer.on_completed();
         }
 
-        void set_upstream(const disposable_wrapper& d) const { state->add(d); }
+        void set_upstream(const disposable_wrapper& d) const { state->disposable.add(d); }
 
-        bool is_disposed() const { return locally_disposed || state->is_disposed(); }
+        bool is_disposed() const { return locally_disposed || state->disposable.is_disposed(); }
     };
 
     template<rpp::constraint::observer TObserver,
@@ -113,15 +117,15 @@ namespace rpp::operators::details
             state->observer.on_completed();
         }
 
-        void set_upstream(const disposable_wrapper& d) { state->add(d); }
+        void set_upstream(const disposable_wrapper& d) { state->disposable.add(d); }
 
-        bool is_disposed() const { return state->is_disposed(); }
+        bool is_disposed() const { return state->disposable.is_disposed(); }
     };
 
     template<rpp::constraint::observer TObserver, typename TObservable, typename TNotifier>
     void drain(const std::shared_ptr<retry_when_state<TObserver, TObservable, TNotifier>>& state)
     {
-        while (!state->is_disposed())
+        while (!state->disposable.is_disposed())
         {
             state->is_inside_drain.store(true, std::memory_order::seq_cst);
             try
@@ -157,10 +161,7 @@ namespace rpp::operators::details
         template<rpp::constraint::observer TObserver, typename TObservable>
         void subscribe(TObserver&& observer, TObservable&& observable) const
         {
-            const auto d   = disposable_wrapper_impl<retry_when_state<std::decay_t<TObserver>, std::decay_t<TObservable>, std::decay_t<TNotifier>>>::make(std::forward<TObserver>(observer), std::forward<TObservable>(observable), notifier);
-            auto       ptr = d.lock();
-
-            ptr->observer.set_upstream(d.as_weak());
+            const auto ptr   = std::make_shared<retry_when_state<std::decay_t<TObserver>, std::decay_t<TObservable>, std::decay_t<TNotifier>>>(std::forward<TObserver>(observer), std::forward<TObservable>(observable), notifier);
             drain(ptr);
         }
     };

--- a/src/rpp/rpp/operators/retry_when.hpp
+++ b/src/rpp/rpp/operators/retry_when.hpp
@@ -160,7 +160,7 @@ namespace rpp::operators::details
         template<rpp::constraint::observer TObserver, typename TObservable>
         void subscribe(TObserver&& observer, TObservable&& observable) const
         {
-            const auto ptr   = std::make_shared<retry_when_state<std::decay_t<TObserver>, std::decay_t<TObservable>, std::decay_t<TNotifier>>>(std::forward<TObserver>(observer), std::forward<TObservable>(observable), notifier);
+            const auto ptr = std::make_shared<retry_when_state<std::decay_t<TObserver>, std::decay_t<TObservable>, std::decay_t<TNotifier>>>(std::forward<TObserver>(observer), std::forward<TObservable>(observable), notifier);
             drain(ptr);
         }
     };

--- a/src/rpp/rpp/operators/with_latest_from.hpp
+++ b/src/rpp/rpp/operators/with_latest_from.hpp
@@ -37,7 +37,7 @@ namespace rpp::operators::details
 
         rpp::utils::tuple<rpp::utils::value_with_mutex<std::optional<RestArgs>>...>& get_values() { return m_values; }
 
-        const TSelector& get_selector() const { return m_selector; }
+        const TSelector&                    get_selector() const { return m_selector; }
         const composite_disposable_wrapper& get_disposable() const { return m_disposable; }
 
     private:

--- a/src/rpp/rpp/operators/zip.hpp
+++ b/src/rpp/rpp/operators/zip.hpp
@@ -21,11 +21,11 @@
 namespace rpp::operators::details
 {
     template<rpp::constraint::observer Observer, typename TSelector, rpp::constraint::decayed_type... Args>
-    class zip_disposable final : public combining_disposable<Observer, Args...>
+    class zip_state final : public combining_state<Observer>
     {
     public:
-        explicit zip_disposable(Observer&& observer, const TSelector& selector)
-            : combining_disposable<Observer, Args...>(std::move(observer))
+        explicit zip_state(Observer&& observer, const TSelector& selector)
+            : combining_state<Observer>(std::move(observer), sizeof...(Args))
             , m_selector(selector)
         {
         }
@@ -42,17 +42,17 @@ namespace rpp::operators::details
 
     template<size_t I, rpp::constraint::observer Observer, typename TSelector, rpp::constraint::decayed_type... Args>
     struct zip_observer_strategy final
-        : public combining_observer_strategy<zip_disposable<Observer, TSelector, Args...>>
+        : public combining_observer_strategy<zip_state<Observer, TSelector, Args...>>
     {
-        using combining_observer_strategy<zip_disposable<Observer, TSelector, Args...>>::disposable;
+        using combining_observer_strategy<zip_state<Observer, TSelector, Args...>>::state;
 
         template<typename T>
         void on_next(T&& v) const
         {
-            const auto observer = disposable->get_observer_under_lock();
-            disposable->get_pendings().template get<I>().push_back(std::forward<T>(v));
+            const auto observer = state->get_observer_under_lock();
+            state->get_pendings().template get<I>().push_back(std::forward<T>(v));
 
-            disposable->get_pendings().apply(&apply_impl<decltype(disposable)>, disposable, observer);
+            state->get_pendings().apply(&apply_impl<decltype(state)>, state, observer);
         }
 
     private:
@@ -68,7 +68,7 @@ namespace rpp::operators::details
     };
 
     template<typename TSelector, rpp::constraint::observable... TObservables>
-    struct zip_t : public combining_operator_t<zip_disposable, zip_observer_strategy, TSelector, TObservables...>
+    struct zip_t : public combining_operator_t<zip_state, zip_observer_strategy, TSelector, TObservables...>
     {
     };
 } // namespace rpp::operators::details

--- a/src/tests/rpp/test_take_until.cpp
+++ b/src/tests/rpp/test_take_until.cpp
@@ -17,9 +17,9 @@
 #include <rpp/operators/take.hpp>
 #include <rpp/operators/take_until.hpp>
 #include <rpp/schedulers/current_thread.hpp>
+#include <rpp/sources/concat.hpp>
 #include <rpp/sources/empty.hpp>
 #include <rpp/sources/error.hpp>
-#include <rpp/sources/concat.hpp>
 #include <rpp/sources/interval.hpp>
 #include <rpp/sources/just.hpp>
 #include <rpp/sources/never.hpp>
@@ -148,7 +148,7 @@ TEST_CASE("take_until can handle race condition")
 
         SECTION("on_completed shall not interleave with on_next")
         {
-                rpp::source::concat(rpp::source::just(1) | rpp::ops::take(1), rpp::source::never<int>())
+            rpp::source::concat(rpp::source::just(1) | rpp::ops::take(1), rpp::source::never<int>())
                 | rpp::ops::take_until(subject.get_observable())
                 | rpp::ops::as_blocking()
                 | rpp::ops::subscribe([&](auto&&) {

--- a/src/tests/rpp/test_take_until.cpp
+++ b/src/tests/rpp/test_take_until.cpp
@@ -14,10 +14,12 @@
 #include <rpp/observers/mock_observer.hpp>
 #include <rpp/operators/as_blocking.hpp>
 #include <rpp/operators/finally.hpp>
+#include <rpp/operators/take.hpp>
 #include <rpp/operators/take_until.hpp>
 #include <rpp/schedulers/current_thread.hpp>
 #include <rpp/sources/empty.hpp>
 #include <rpp/sources/error.hpp>
+#include <rpp/sources/concat.hpp>
 #include <rpp/sources/interval.hpp>
 #include <rpp/sources/just.hpp>
 #include <rpp/sources/never.hpp>
@@ -146,7 +148,7 @@ TEST_CASE("take_until can handle race condition")
 
         SECTION("on_completed shall not interleave with on_next")
         {
-            rpp::source::interval(std::chrono::milliseconds{200}, rpp::schedulers::current_thread{})
+                rpp::source::concat(rpp::source::just(1) | rpp::ops::take(1), rpp::source::never<int>())
                 | rpp::ops::take_until(subject.get_observable())
                 | rpp::ops::as_blocking()
                 | rpp::ops::subscribe([&](auto&&) {
@@ -173,7 +175,7 @@ TEST_CASE("take_until can handle race condition")
 
         SECTION("on_error shall not interleave with on_next")
         {
-            rpp::source::interval(std::chrono::milliseconds{200}, rpp::schedulers::current_thread{})
+            rpp::source::concat(rpp::source::just(1) | rpp::ops::take(1), rpp::source::never<int>())
                 | rpp::ops::take_until(subject.get_observable())
                 | rpp::ops::as_blocking()
                 | rpp::ops::subscribe([&](auto&&) {


### PR DESCRIPTION
Some operators could dispose disposables early due to ACTUALLY obserable is not going to use observer, but it can be a bit not expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced memory management and observer handling in the `concat_state_t` class.
	- Improved resource management with a new shared pointer for disposable resources.

- **Bug Fixes**
	- Centralized disposal logic for better clarity and reliability in resource management.

- **Documentation**
	- Updated comments and documentation to reflect changes in class structures and functionalities.

- **Tests**
	- Added a new test case to verify the correct management of disposables in observable interactions.
	- Updated test cases for the `take_until` operator to improve robustness against race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->