### PR TITLE
Add rppasio to coverage

### DIFF
--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -4,7 +4,7 @@ if (NOT RPP_BUILD_TESTS_TOGETHER)
     message( FATAL_ERROR "Expected to set RPP_BUILD_TESTS_TOGETHER flag when build coverage via llvm cov")
 endif()
 
-set(RPP_COVERAGE_TARGETS -instr-profile=${RPP_TEST_RESULTS_DIR}/results.profdata -object $<TARGET_FILE:test_rpp> -object $<TARGET_FILE:test_rppqt> -object $<TARGET_FILE:test_rppgrpc>)
+set(RPP_COVERAGE_TARGETS -instr-profile=${RPP_TEST_RESULTS_DIR}/results.profdata -object $<TARGET_FILE:test_rpp> -object $<TARGET_FILE:test_rppqt> -object $<TARGET_FILE:test_rppgrpc> -object $<TARGET_FILE:test_rppasio>)
 
 add_custom_target(
     coverage

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -9,6 +9,7 @@ install(
        src/rpp
        src/extensions/rppqt
        src/extensions/rppgrpc
+       src/extensions/rppasio
     DESTINATION
         "${CMAKE_INSTALL_INCLUDEDIR}"
     COMPONENT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced coverage reporting to include the `test_rppasio` target.
	- Introduced a new installation target for the `rppasio` component, ensuring its inclusion in installation processes.

- **Documentation**
	- Updated installation rules to reflect the addition of the `rppasio` directory and its associated targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->