### PR TITLE
Revert "try add -show-instantiations=false"

### DIFF
--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -10,6 +10,6 @@ add_custom_target(
     coverage
     COMMAND llvm-profdata merge -o ${RPP_TEST_RESULTS_DIR}/results.profdata ${RPP_TEST_RESULTS_DIR}/*.profraw
     COMMAND llvm-cov report --ignore-filename-regex=build ${RPP_COVERAGE_TARGETS}
-    COMMAND llvm-cov show --show-instantiations=false --ignore-filename-regex=build --show-branches=count ${RPP_COVERAGE_TARGETS} > ${RPP_TEST_RESULTS_DIR}/coverage.txt
+    COMMAND llvm-cov show --ignore-filename-regex=build --show-branches=count ${RPP_COVERAGE_TARGETS} > ${RPP_TEST_RESULTS_DIR}/coverage.txt
     COMMENT "Generating coverage report"
 )


### PR DESCRIPTION
Reverts victimsnino/ReactivePlusPlus#658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the coverage report generation command for improved clarity and output.
	- Removed the `--show-instantiations=false` option, allowing for a more comprehensive report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->