### PR TITLE
Fix deadlocks in operators related to is_disposed

### DIFF
--- a/src/rpp/rpp/disposables/details/base_disposable.hpp
+++ b/src/rpp/rpp/disposables/details/base_disposable.hpp
@@ -41,7 +41,7 @@ namespace rpp::details
         }
 
     protected:
-        virtual void base_dispose_impl(interface_disposable::Mode mode) noexcept = 0;
+        virtual void base_dispose_impl(interface_disposable::Mode ) noexcept {};
 
     private:
         std::atomic_bool m_disposed{};

--- a/src/rpp/rpp/disposables/details/base_disposable.hpp
+++ b/src/rpp/rpp/disposables/details/base_disposable.hpp
@@ -41,7 +41,7 @@ namespace rpp::details
         }
 
     protected:
-        virtual void base_dispose_impl(interface_disposable::Mode ) noexcept {};
+        virtual void base_dispose_impl(interface_disposable::Mode) noexcept {};
 
     private:
         std::atomic_bool m_disposed{};

--- a/src/rpp/rpp/operators/debounce.hpp
+++ b/src/rpp/rpp/operators/debounce.hpp
@@ -31,7 +31,8 @@ namespace rpp::operators::details
     };
 
     template<rpp::constraint::observer Observer, typename Worker>
-    class debounce_state final : public rpp::details::enable_wrapper_from_this<debounce_state<Observer, Worker>>, public rpp::details::base_disposable
+    class debounce_state final : public rpp::details::enable_wrapper_from_this<debounce_state<Observer, Worker>>
+        , public rpp::details::base_disposable
     {
         using T = rpp::utils::extract_observer_type_t<Observer>;
 
@@ -163,7 +164,7 @@ namespace rpp::operators::details
         {
             using worker_t = rpp::schedulers::utils::get_worker_t<Scheduler>;
 
-            auto d = rpp::disposable_wrapper_impl<debounce_state<std::decay_t<Observer>, worker_t>>::make(std::forward<Observer>(observer), scheduler.create_worker(), duration);
+            auto d   = rpp::disposable_wrapper_impl<debounce_state<std::decay_t<Observer>, worker_t>>::make(std::forward<Observer>(observer), scheduler.create_worker(), duration);
             auto ptr = d.lock();
             ptr->get_observer_under_lock()->set_upstream(d.as_weak());
             return rpp::observer<Type, debounce_observer_strategy<std::decay_t<Observer>, worker_t>>{std::move(ptr)};

--- a/src/rpp/rpp/operators/details/combining_strategy.hpp
+++ b/src/rpp/rpp/operators/details/combining_strategy.hpp
@@ -22,7 +22,7 @@
 namespace rpp::operators::details
 {
     template<rpp::constraint::observer Observer>
-    class combining_state
+    class combining_state : public rpp::details::enable_wrapper_from_this<combining_state<Observer>>, public rpp::details::base_disposable
     {
     public:
         explicit combining_state(Observer&& observer, size_t on_completed_needed)
@@ -57,7 +57,7 @@ namespace rpp::operators::details
 
         bool is_disposed() const
         {
-            return state->get_observer_under_lock()->is_disposed();
+            return state->is_disposed();
         }
 
         void on_error(const std::exception_ptr& err) const
@@ -103,7 +103,10 @@ namespace rpp::operators::details
         {
             using State = TState<Observer, TSelector, Type, rpp::utils::extract_observable_type_t<TObservables>...>;
 
-            const auto state = std::make_shared<State>(std::forward<Observer>(observer), selector);
+            const auto d = rpp::disposable_wrapper_impl<State>::make(std::forward<Observer>(observer), selector);
+            auto state = d.lock();
+            state->get_observer_under_lock()->set_upstream(d.as_weak());
+
             subscribe<std::decay_t<Type>>(state, std::index_sequence_for<TObservables...>{}, observables...);
 
             return rpp::observer<Type, TStrategy<0, std::decay_t<Observer>, TSelector, Type, rpp::utils::extract_observable_type_t<TObservables>...>>{std::move(state)};

--- a/src/rpp/rpp/operators/details/combining_strategy.hpp
+++ b/src/rpp/rpp/operators/details/combining_strategy.hpp
@@ -22,7 +22,8 @@
 namespace rpp::operators::details
 {
     template<rpp::constraint::observer Observer>
-    class combining_state : public rpp::details::enable_wrapper_from_this<combining_state<Observer>>, public rpp::details::base_disposable
+    class combining_state : public rpp::details::enable_wrapper_from_this<combining_state<Observer>>
+        , public rpp::details::base_disposable
     {
     public:
         explicit combining_state(Observer&& observer, size_t on_completed_needed)
@@ -103,8 +104,8 @@ namespace rpp::operators::details
         {
             using State = TState<Observer, TSelector, Type, rpp::utils::extract_observable_type_t<TObservables>...>;
 
-            const auto d = rpp::disposable_wrapper_impl<State>::make(std::forward<Observer>(observer), selector);
-            auto state = d.lock();
+            const auto d     = rpp::disposable_wrapper_impl<State>::make(std::forward<Observer>(observer), selector);
+            auto       state = d.lock();
             state->get_observer_under_lock()->set_upstream(d.as_weak());
 
             subscribe<std::decay_t<Type>>(state, std::index_sequence_for<TObservables...>{}, observables...);

--- a/src/rpp/rpp/operators/merge.hpp
+++ b/src/rpp/rpp/operators/merge.hpp
@@ -69,7 +69,7 @@ namespace rpp::operators::details
 
         bool is_disposed() const
         {
-            return m_state->get_observer_under_lock()->is_disposed();
+            return m_state->get_disposable().is_disposed();
         }
 
         void on_error(const std::exception_ptr& err) const

--- a/src/tests/rpp/test_combine_latest.cpp
+++ b/src/tests/rpp/test_combine_latest.cpp
@@ -142,15 +142,15 @@ TEST_CASE("combine_latest is not deadlocking is_disposed")
 {
     std::optional<rpp::dynamic_observer<int>> observer{};
 
-    rpp::source::create<int>([&observer](auto&& obs){
+    rpp::source::create<int>([&observer](auto&& obs) {
         observer = std::forward<decltype(obs)>(obs).as_dynamic();
         observer->on_next(1);
     })
-    | rpp::operators::combine_latest(rpp::source::just(1))
-    | rpp::ops::subscribe([&observer](auto){
-        CHECK(observer);
-        CHECK(!observer->is_disposed());
-    });
+        | rpp::operators::combine_latest(rpp::source::just(1))
+        | rpp::ops::subscribe([&observer](auto) {
+              CHECK(observer);
+              CHECK(!observer->is_disposed());
+          });
 }
 
 TEST_CASE("combine_latest satisfies disposable contracts")

--- a/src/tests/rpp/test_combine_latest.cpp
+++ b/src/tests/rpp/test_combine_latest.cpp
@@ -138,6 +138,21 @@ TEST_CASE("combine_latest handles race condition")
     }
 }
 
+TEST_CASE("combine_latest is not deadlocking is_disposed")
+{
+    std::optional<rpp::dynamic_observer<int>> observer{};
+
+    rpp::source::create<int>([&observer](auto&& obs){
+        observer = std::forward<decltype(obs)>(obs).as_dynamic();
+        observer->on_next(1);
+    })
+    | rpp::operators::combine_latest(rpp::source::just(1))
+    | rpp::ops::subscribe([&observer](auto){
+        CHECK(observer);
+        CHECK(!observer->is_disposed());
+    });
+}
+
 TEST_CASE("combine_latest satisfies disposable contracts")
 {
     auto observable_disposable = rpp::composite_disposable_wrapper::make();

--- a/src/tests/rpp/test_debounce.cpp
+++ b/src/tests/rpp/test_debounce.cpp
@@ -120,6 +120,26 @@ TEST_CASE("debounce emit only items where timeout reached")
     }
 }
 
+
+TEST_CASE("debounce is not deadlocking is_disposed")
+{
+    std::optional<rpp::dynamic_observer<int>> observer{};
+
+    rpp::schedulers::test_scheduler scheduler{};
+
+    rpp::source::create<int>([&observer](auto&& obs){
+        observer = std::forward<decltype(obs)>(obs).as_dynamic();
+        observer->on_next(1);
+    })
+    | rpp::operators::debounce(std::chrono::seconds{1}, scheduler)
+    | rpp::ops::subscribe([&observer](int){
+        CHECK(observer);
+        CHECK(!observer->is_disposed());
+    });
+    scheduler.time_advance(std::chrono::seconds{1});
+}
+
+
 TEST_CASE("debounce forwards error")
 {
     auto mock = mock_observer_strategy<int>{};

--- a/src/tests/rpp/test_debounce.cpp
+++ b/src/tests/rpp/test_debounce.cpp
@@ -127,15 +127,15 @@ TEST_CASE("debounce is not deadlocking is_disposed")
 
     rpp::schedulers::test_scheduler scheduler{};
 
-    rpp::source::create<int>([&observer](auto&& obs){
+    rpp::source::create<int>([&observer](auto&& obs) {
         observer = std::forward<decltype(obs)>(obs).as_dynamic();
         observer->on_next(1);
     })
-    | rpp::operators::debounce(std::chrono::seconds{1}, scheduler)
-    | rpp::ops::subscribe([&observer](int){
-        CHECK(observer);
-        CHECK(!observer->is_disposed());
-    });
+        | rpp::operators::debounce(std::chrono::seconds{1}, scheduler)
+        | rpp::ops::subscribe([&observer](int) {
+              CHECK(observer);
+              CHECK(!observer->is_disposed());
+          });
     scheduler.time_advance(std::chrono::seconds{1});
 }
 

--- a/src/tests/rpp/test_merge.cpp
+++ b/src/tests/rpp/test_merge.cpp
@@ -258,6 +258,20 @@ TEST_CASE("merge dispose inner_disposable immediately")
         | rpp::ops::subscribe([](int) {});
 }
 
+TEST_CASE("merge is not deadlocking is_disposed")
+{
+    std::optional<rpp::dynamic_observer<int>> observer{};
+    rpp::source::create<int>([&observer](auto&& obs){
+        observer = std::forward<decltype(obs)>(obs).as_dynamic();
+        observer->on_next(1);
+    })
+    | rpp::ops::merge_with(rpp::source::never<int>())
+    | rpp::ops::subscribe([&observer](int){
+        CHECK(observer);
+        CHECK(!observer->is_disposed());
+    });
+}
+
 TEST_CASE("merge doesn't produce extra copies")
 {
     SUBCASE("send value by copy")

--- a/src/tests/rpp/test_merge.cpp
+++ b/src/tests/rpp/test_merge.cpp
@@ -261,15 +261,15 @@ TEST_CASE("merge dispose inner_disposable immediately")
 TEST_CASE("merge is not deadlocking is_disposed")
 {
     std::optional<rpp::dynamic_observer<int>> observer{};
-    rpp::source::create<int>([&observer](auto&& obs){
+    rpp::source::create<int>([&observer](auto&& obs) {
         observer = std::forward<decltype(obs)>(obs).as_dynamic();
         observer->on_next(1);
     })
-    | rpp::ops::merge_with(rpp::source::never<int>())
-    | rpp::ops::subscribe([&observer](int){
-        CHECK(observer);
-        CHECK(!observer->is_disposed());
-    });
+        | rpp::ops::merge_with(rpp::source::never<int>())
+        | rpp::ops::subscribe([&observer](int) {
+              CHECK(observer);
+              CHECK(!observer->is_disposed());
+          });
 }
 
 TEST_CASE("merge doesn't produce extra copies")

--- a/src/tests/rpp/test_zip.cpp
+++ b/src/tests/rpp/test_zip.cpp
@@ -175,6 +175,21 @@ TEST_CASE("zip doesn't produce extra copies")
     }
 }
 
+TEST_CASE("zip is not deadlocking is_disposed")
+{
+    std::optional<rpp::dynamic_observer<int>> observer{};
+
+    rpp::source::create<int>([&observer](auto&& obs){
+        observer = std::forward<decltype(obs)>(obs).as_dynamic();
+        observer->on_next(1);
+    })
+    | rpp::operators::zip(rpp::source::just(1))
+    | rpp::ops::subscribe([&observer](auto){
+        CHECK(observer);
+        CHECK(!observer->is_disposed());
+    });
+}
+
 TEST_CASE("zip satisfies disposable contracts")
 {
     auto observable_disposable = rpp::composite_disposable_wrapper::make();

--- a/src/tests/rpp/test_zip.cpp
+++ b/src/tests/rpp/test_zip.cpp
@@ -179,15 +179,15 @@ TEST_CASE("zip is not deadlocking is_disposed")
 {
     std::optional<rpp::dynamic_observer<int>> observer{};
 
-    rpp::source::create<int>([&observer](auto&& obs){
+    rpp::source::create<int>([&observer](auto&& obs) {
         observer = std::forward<decltype(obs)>(obs).as_dynamic();
         observer->on_next(1);
     })
-    | rpp::operators::zip(rpp::source::just(1))
-    | rpp::ops::subscribe([&observer](auto){
-        CHECK(observer);
-        CHECK(!observer->is_disposed());
-    });
+        | rpp::operators::zip(rpp::source::just(1))
+        | rpp::ops::subscribe([&observer](auto) {
+              CHECK(observer);
+              CHECK(!observer->is_disposed());
+          });
 }
 
 TEST_CASE("zip satisfies disposable contracts")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Default implementation for disposal methods in base classes, simplifying derived class requirements.
	- Enhanced memory management in several operator classes for better performance and reliability.

- **Bug Fixes**
	- Added tests to ensure operators do not deadlock when observers are disposed, improving stability.

- **Tests**
	- Introduced new test cases for `combine_latest`, `debounce`, `merge`, and `zip` operators to verify non-deadlocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->