### PR TITLE
repeat_when operator

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: "build/"

--- a/src/rpp/rpp/operators.hpp
+++ b/src/rpp/rpp/operators.hpp
@@ -174,6 +174,7 @@
 #include <rpp/operators/finally.hpp>
 #include <rpp/operators/observe_on.hpp>
 #include <rpp/operators/repeat.hpp>
+#include <rpp/operators/repeat_when.hpp>
 #include <rpp/operators/subscribe_on.hpp>
 #include <rpp/operators/tap.hpp>
 #include <rpp/operators/timeout.hpp>

--- a/src/rpp/rpp/operators/details/repeating_strategy.hpp
+++ b/src/rpp/rpp/operators/details/repeating_strategy.hpp
@@ -1,0 +1,122 @@
+//                  ReactivePlusPlus library
+//
+//          Copyright Aleksey Loginov 2023 - present.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/victimsnino/ReactivePlusPlus
+//
+
+#pragma once
+
+#include <rpp/observables/fwd.hpp>
+#include <rpp/operators/fwd.hpp>
+
+#include <rpp/defs.hpp>
+#include <rpp/operators/details/strategy.hpp>
+#include <rpp/utils/constraints.hpp>
+#include <rpp/utils/utils.hpp>
+
+#include "rpp/observers/fwd.hpp"
+
+namespace rpp::operators::details
+{
+    template<rpp::constraint::observer TObserver,
+             typename TObservable,
+             typename TNotifier>
+    struct repeating_state final : public rpp::composite_disposable
+    {
+        repeating_state(TObserver&& observer, const TObservable& observable, const TNotifier& notifier)
+            : observer(std::move(observer))
+            , observable(observable)
+            , notifier(notifier)
+        {
+        }
+
+        std::atomic_bool is_inside_drain{};
+
+        RPP_NO_UNIQUE_ADDRESS TObserver   observer;
+        RPP_NO_UNIQUE_ADDRESS TObservable observable;
+        RPP_NO_UNIQUE_ADDRESS TNotifier   notifier;
+    };
+
+    template<typename TStrategy, rpp::constraint::observer TObserver, typename TObservable, typename TNotifier>
+    void drain(const std::shared_ptr<repeating_state<TObserver, TObservable, TNotifier>>& state);
+
+    template<typename TOuterStrategy,
+             rpp::constraint::observer TObserver,
+             typename TObservable,
+             typename TNotifier>
+    struct repeating_inner_observer_strategy
+    {
+        static constexpr auto preferred_disposables_mode = rpp::details::observers::disposables_mode::None;
+
+        std::shared_ptr<repeating_state<TObserver, TObservable, TNotifier>> state;
+        mutable bool                                                        locally_disposed{};
+
+        template<typename T>
+        void on_next(T&&) const
+        {
+            locally_disposed = true;
+            state->clear();
+
+            if (state->is_inside_drain.exchange(false, std::memory_order::seq_cst))
+                return;
+
+            drain<TOuterStrategy>(state);
+        }
+
+        void on_error(const std::exception_ptr& err) const
+        {
+            locally_disposed = true;
+            state->observer.on_error(err);
+        }
+
+        void on_completed() const
+        {
+            locally_disposed = true;
+            state->observer.on_completed();
+        }
+
+        void set_upstream(const disposable_wrapper& d) const { state->add(d); }
+
+        bool is_disposed() const { return locally_disposed || state->is_disposed(); }
+    };
+
+    template<rpp::constraint::observer TObserver,
+             typename TObservable,
+             typename TNotifier>
+    struct repeating_observer_strategy
+    {
+        static constexpr auto preferred_disposables_mode = rpp::details::observers::disposables_mode::None;
+
+        std::shared_ptr<repeating_state<TObserver, TObservable, TNotifier>> state;
+
+        void set_upstream(const disposable_wrapper& d) { state->add(d); }
+
+        bool is_disposed() const { return state->is_disposed(); }
+    };
+
+    template<typename TStrategy, rpp::constraint::observer TObserver, typename TObservable, typename TNotifier>
+    void drain(const std::shared_ptr<repeating_state<TObserver, TObservable, TNotifier>>& state)
+    {
+        while (!state->is_disposed())
+        {
+            state->is_inside_drain.store(true, std::memory_order::seq_cst);
+            try
+            {
+                using value_type = rpp::utils::extract_observer_type_t<TObserver>;
+                state->observable.subscribe(rpp::observer<value_type, TStrategy>{state});
+
+                if (state->is_inside_drain.exchange(false, std::memory_order::seq_cst))
+                    return;
+            }
+            catch (...)
+            {
+                state->observer.on_error(std::current_exception());
+                return;
+            }
+        }
+    }
+} // namespace rpp::operators::details

--- a/src/rpp/rpp/operators/fwd.hpp
+++ b/src/rpp/rpp/operators/fwd.hpp
@@ -185,6 +185,10 @@ namespace rpp::operators
     auto on_error_resume_next(Selector&& selector);
 
     template<typename Notifier>
+        requires rpp::constraint::observable<std::invoke_result_t<Notifier>>
+    auto repeat_when(Notifier&& notifier);
+
+    template<typename Notifier>
         requires rpp::constraint::observable<std::invoke_result_t<Notifier, std::exception_ptr>>
     auto retry_when(Notifier&& notifier);
 

--- a/src/rpp/rpp/operators/repeat_when.hpp
+++ b/src/rpp/rpp/operators/repeat_when.hpp
@@ -20,9 +20,9 @@ namespace rpp::operators::details
     template<rpp::constraint::observer TObserver,
              typename TObservable,
              typename TNotifier>
-    struct retry_when_impl_strategy final : public repeating_observer_strategy<TObserver, TObservable, TNotifier>
+    struct repeat_when_impl_strategy final : public repeating_observer_strategy<TObserver, TObservable, TNotifier>
     {
-        using self_type = retry_when_impl_strategy<TObserver, TObservable, TNotifier>;
+        using self_type = repeat_when_impl_strategy<TObserver, TObservable, TNotifier>;
 
         using repeating_observer_strategy<TObserver, TObservable, TNotifier>::state;
 
@@ -34,24 +34,24 @@ namespace rpp::operators::details
 
         void on_error(const std::exception_ptr& err) const
         {
+            state->observer.on_error(err);
+        }
+
+        void on_completed() const
+        {
             try
             {
-                state->notifier(err).subscribe(repeating_inner_observer_strategy<self_type, TObserver, TObservable, TNotifier>{this->state});
+                state->notifier().subscribe(repeating_inner_observer_strategy<self_type, TObserver, TObservable, TNotifier>{this->state});
             }
             catch (...)
             {
                 state->observer.on_error(std::current_exception());
             }
         }
-
-        void on_completed() const
-        {
-            state->observer.on_completed();
-        }
     };
 
     template<rpp::constraint::decayed_type TNotifier>
-    struct retry_when_t
+    struct repeat_when_t
     {
         RPP_NO_UNIQUE_ADDRESS TNotifier notifier;
 
@@ -72,7 +72,7 @@ namespace rpp::operators::details
 
             ptr->observer.set_upstream(d.as_weak());
 
-            drain<retry_when_impl_strategy<std::decay_t<TObserver>, std::decay_t<TObservable>, std::decay_t<TNotifier>>>(ptr);
+            drain<repeat_when_impl_strategy<std::decay_t<TObserver>, std::decay_t<TObservable>, std::decay_t<TNotifier>>>(ptr);
         }
     };
 } // namespace rpp::operators::details
@@ -80,30 +80,21 @@ namespace rpp::operators::details
 namespace rpp::operators
 {
     /**
-     * @brief If an error occurs, invoke @p notifier and when returned observable emits a value
+     * @brief If observable completes, invoke @p notifier and when returned observable emits a value
      * resubscribe to the source observable. If the notifier throws or returns an error/empty
      * observable, then error/completed emission is forwarded to original subscription.
      *
-     * @param notifier callable taking a std::exception_ptr and returning observable notifying when to resubscribe
+     * @param notifier callable taking no arguments and returning observable notifying when to resubscribe
      *
-     * @warning retry_when along with other re-subscribing operators needs to be carefully used with
-     * hot observables, as re-subscribing to a hot observable can have unwanted behaviors. For example,
-     * a hot observable behind a replay subject can indefinitely yield an error on each re-subscription
-     * and using retry_when on it would lead to an infinite execution.
+     * @note `#include <rpp/operators/repeat_when.hpp>`
      *
-     * @note `#include <rpp/operators/retry_when.hpp>`
-     *
-     * @par Examples:
-     * @snippet retry_when.cpp retry_when delay
-     * @snippet retry_when.cpp retry_when
-     *
-     * @ingroup error_handling_operators
-     * @see https://reactivex.io/documentation/operators/retry.html
+     * @ingroup creational_operators
+     * @see https://reactivex.io/documentation/operators/repeat.html
      */
     template<typename TNotifier>
-        requires rpp::constraint::observable<std::invoke_result_t<TNotifier, std::exception_ptr>>
-    auto retry_when(TNotifier&& notifier)
+        requires rpp::constraint::observable<std::invoke_result_t<TNotifier>>
+    auto repeat_when(TNotifier&& notifier)
     {
-        return details::retry_when_t<std::decay_t<TNotifier>>{std::forward<TNotifier>(notifier)};
+        return details::repeat_when_t<std::decay_t<TNotifier>>{std::forward<TNotifier>(notifier)};
     }
 } // namespace rpp::operators

--- a/src/rpp/rpp/operators/retry_when.hpp
+++ b/src/rpp/rpp/operators/retry_when.hpp
@@ -97,7 +97,7 @@ namespace rpp::operators
      * @snippet retry_when.cpp retry_when delay
      * @snippet retry_when.cpp retry_when
      *
-     * @ingroup error_handling_operators
+     * @ingroup utility_operators
      * @see https://reactivex.io/documentation/operators/retry.html
      */
     template<typename TNotifier>

--- a/src/tests/rpp/test_repeat_when.cpp
+++ b/src/tests/rpp/test_repeat_when.cpp
@@ -1,0 +1,174 @@
+//                  ReactivePlusPlus library
+//
+//          Copyright Aleksey Loginov 2023 - present.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/victimsnino/ReactivePlusPlus
+//
+
+#include <doctest/doctest.h>
+
+#include <rpp/observables/dynamic_observable.hpp>
+#include <rpp/observers/mock_observer.hpp>
+#include <rpp/operators/as_blocking.hpp>
+#include <rpp/operators/repeat_when.hpp>
+#include <rpp/schedulers/immediate.hpp>
+#include <rpp/schedulers/new_thread.hpp>
+#include <rpp/sources/concat.hpp>
+#include <rpp/sources/create.hpp>
+#include <rpp/sources/empty.hpp>
+#include <rpp/sources/error.hpp>
+#include <rpp/sources/just.hpp>
+
+#include "copy_count_tracker.hpp"
+#include "disposable_observable.hpp"
+#include "rpp_trompeloil.hpp"
+
+#include <string>
+
+TEST_CASE("repeat_when resubscribes on notifier emission")
+{
+    mock_observer<std::string> mock{};
+    trompeloeil::sequence      seq;
+    size_t                     subscribe_count = 0;
+    auto                       observable      = rpp::source::create<std::string>([&subscribe_count](const auto& sub) {
+        sub.on_next(std::to_string(++subscribe_count));
+        sub.on_completed();
+    });
+
+    SUBCASE("empty notifier")
+    {
+        REQUIRE_CALL(*mock, on_next_rvalue("1")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_completed()).IN_SEQUENCE(seq);
+
+        observable
+            | rpp::operators::repeat_when([]() { return rpp::source::empty<int>(); })
+            | rpp::operators::subscribe(mock);
+
+        CHECK(subscribe_count == 1);
+    }
+
+    SUBCASE("notifier resubscribes once")
+    {
+        size_t i = 0;
+
+        REQUIRE_CALL(*mock, on_next_rvalue("1")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_next_rvalue("2")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_completed()).IN_SEQUENCE(seq);
+
+        observable
+            | rpp::operators::repeat_when([&i]() {
+                  if (i++ != 0)
+                      return rpp::source::empty<int>().as_dynamic();
+                  return rpp::source::just(1).as_dynamic();
+              })
+            | rpp::operators::subscribe(mock);
+
+        CHECK(subscribe_count == 2);
+    }
+
+    SUBCASE("notifier resubscribes multiple times")
+    {
+        size_t i = 0;
+
+        REQUIRE_CALL(*mock, on_next_rvalue("1")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_next_rvalue("2")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_next_rvalue("3")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_next_rvalue("4")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_completed()).IN_SEQUENCE(seq);
+
+        observable
+            | rpp::operators::repeat_when([&i]() {
+                  if (i++ >= 3)
+                      return rpp::source::empty<int>().as_dynamic();
+                  return rpp::source::just(1).as_dynamic();
+              })
+            | rpp::operators::subscribe(mock);
+
+        CHECK(subscribe_count == 4);
+    }
+
+    SUBCASE("notifier throws")
+    {
+        REQUIRE_CALL(*mock, on_next_rvalue("1")).IN_SEQUENCE(seq);
+        REQUIRE_CALL(*mock, on_error(trompeloeil::_)).IN_SEQUENCE(seq);
+
+        observable
+            | rpp::operators::repeat_when([]() {
+                  throw std::runtime_error{""};
+                  return rpp::source::just(1);
+              })
+            | rpp::operators::subscribe(mock);
+
+        CHECK(subscribe_count == 1);
+    }
+}
+
+TEST_CASE("repeat_when does not stack overflow")
+{
+    mock_observer<int>    mock{};
+    trompeloeil::sequence seq;
+
+    constexpr size_t count = 500000;
+
+    REQUIRE_CALL(*mock, on_next_rvalue(trompeloeil::_)).TIMES(count).IN_SEQUENCE(seq);
+    REQUIRE_CALL(*mock, on_completed()).IN_SEQUENCE(seq);
+
+    rpp::source::create<int>([](const auto& obs) {
+        obs.on_next(1);
+        obs.on_completed();
+    })
+        | rpp::operators::repeat_when([i = count]() mutable {
+            if (--i != 0)
+                return rpp::source::just(rpp::schedulers::immediate{}, 1).as_dynamic(); // Use immediate scheduler for recursion
+            return rpp::source::empty<int>().as_dynamic(); })
+        | rpp::operators::subscribe(mock);
+}
+
+TEST_CASE("repeat_when disposes on looping")
+{
+    mock_observer<int> mock{};
+    REQUIRE_CALL(*mock, on_next_rvalue(1)).TIMES(2);
+    REQUIRE_CALL(*mock, on_completed());
+
+    size_t i = 0;
+
+    rpp::source::concat(rpp::source::create<int>([](auto&& subscriber) {
+        auto d = rpp::composite_disposable_wrapper::make();
+        subscriber.set_upstream(d);
+        subscriber.on_next(1);
+        subscriber.on_completed();
+        CHECK(d.is_disposed());
+    })) | rpp::ops::repeat_when([&i]() { return i++ ? rpp::source::empty<int>().as_dynamic() : rpp::source::just(1).as_dynamic(); })
+        | rpp::ops::subscribe(mock);
+}
+
+TEST_CASE("repeat_when doesn't produce extra copies")
+{
+    SUBCASE("repeat_when(empty_notifier)")
+    {
+        copy_count_tracker::test_operator(rpp::ops::repeat_when([]() { return rpp::source::empty<int>(); }),
+                                          {
+                                              .send_by_copy = {.copy_count = 1, // 1 copy to final subscriber
+                                                               .move_count = 0},
+                                              .send_by_move = {.copy_count = 0,
+                                                               .move_count = 1} // 1 move to final subscriber
+                                          });
+    }
+}
+
+TEST_CASE("repeat_when satisfies disposable contracts")
+{
+
+    test_operator_with_disposable<int>(rpp::ops::repeat_when([]() { return rpp::source::empty<int>(); }));
+    test_operator_finish_before_dispose<int>(rpp::ops::repeat_when([]() { return rpp::source::empty<int>(); }));
+
+    test_operator_over_observable_with_disposable<int>(
+        [](auto observable) {
+            auto c = std::make_shared<size_t>();
+            return rpp::source::concat(observable, rpp::source::error<int>(std::make_exception_ptr(std::runtime_error{"error"})))
+                 | rpp::ops::repeat_when([c]() -> rpp::dynamic_observable<int> {  if ((*c)++ ==0) return rpp::source::just(1); return rpp::source::empty<int>(); });
+        });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new operator that allows repeating an observable sequence based on emissions from a notifier observable.
  - Added a configuration file to improve code analysis and completion features in development environments.

- **Refactor**
  - Streamlined the internal logic for retrying observables, improving maintainability and consistency.

- **Tests**
  - Added comprehensive tests to verify correct behavior, error handling, and performance of the new repeat operator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->