### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/ci v2.yml
+++ b/.github/workflows/ci v2.yml
@@ -46,11 +46,7 @@ jobs:
     - name: Ensure Jinja2 available to Conan
       shell: bash
       run: |
-        if command -v pipx >/dev/null 2>&1; then
-          pipx inject --install conan "Jinja2>=3.1.5,<3.2"
-        else
           python -m pip install --upgrade "Jinja2>=3.1.5,<3.2"
-        fi
 
     - name: check cache
       uses: actions/cache@v4

--- a/.github/workflows/ci v2.yml
+++ b/.github/workflows/ci v2.yml
@@ -40,6 +40,8 @@ jobs:
       with:
         python-version: '3.6.x - 3.11.x'
 
+    - run: pip install jinja2
+
     - name: get conan
       uses: turtlebrowser/get-conan@main
 

--- a/.github/workflows/ci v2.yml
+++ b/.github/workflows/ci v2.yml
@@ -40,10 +40,17 @@ jobs:
       with:
         python-version: '3.6.x - 3.11.x'
 
-    - run: pip install jinja2
-
     - name: get conan
       uses: turtlebrowser/get-conan@main
+
+    - name: Ensure Jinja2 available to Conan
+      shell: bash
+      run: |
+        if command -v pipx >/dev/null 2>&1; then
+          pipx inject --install conan "Jinja2>=3.1.5,<3.2"
+        else
+          python -m pip install --upgrade "Jinja2>=3.1.5,<3.2"
+        fi
 
     - name: check cache
       uses: actions/cache@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,7 +38,7 @@
       "inherits" : ["ci-flags"],
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fno-rtti -Wall -Werror -Wextra -Wpedantic -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wno-gnu-zero-variadic-macro-arguments -Wno-error=maybe-uninitialized -Wno-error=uninitialized -Wno-unknown-warning-option"
+        "CMAKE_CXX_FLAGS": "-fno-rtti -Wall -Werror -Wextra -Wpedantic -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wno-gnu-zero-variadic-macro-arguments -Wno-error=maybe-uninitialized -Wno-error=uninitialized -Wno-unknown-warning-option -Wmissing-template-arg-list-after-template-kw"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,7 +38,7 @@
       "inherits" : ["ci-flags"],
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fno-rtti -Wall -Werror -Wextra -Wpedantic -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wno-gnu-zero-variadic-macro-arguments -Wno-error=maybe-uninitialized -Wno-error=uninitialized -Wno-unknown-warning-option -Wmissing-template-arg-list-after-template-kw"
+        "CMAKE_CXX_FLAGS": "-fno-rtti -Wall -Werror -Wextra -Wpedantic -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wno-gnu-zero-variadic-macro-arguments -Wno-error=maybe-uninitialized -Wno-error=uninitialized -Wno-unknown-warning-option"
       }
     },
     {
@@ -57,6 +57,14 @@
       "inherits": ["flags-unix"],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ci-macos",
+      "hidden": true,
+      "inherits": ["ci-unix"],
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-Wmissing-template-arg-list-after-template-kw"
       }
     },
     {
@@ -219,7 +227,7 @@
     },
     {
       "name": "ci-macos-tests",
-      "inherits": ["ci-build", "build-tests", "build-examples", "build-qt", "build-grpc", "build-asio", "build-sfml", "ci-unix"]
+      "inherits": ["ci-build", "build-tests", "build-examples", "build-qt", "build-grpc", "build-asio", "build-sfml", "ci-macos"]
     },
     {
       "name": "ci-ubuntu-clang-tests",
@@ -242,7 +250,7 @@
 
     {
       "name": "ci-macos-benchmarks",
-      "inherits": ["ci-build", "build-benchmarks", "ci-unix"]
+      "inherits": ["ci-build", "build-benchmarks", "ci-macos"]
     },
     {
       "name": "ci-ubuntu-clang-benchmarks",
@@ -264,7 +272,7 @@
           "build-dir",
           "build-tests",
           "build-examples",
-          "ci-unix"
+          "ci-macos"
       ]
     },
     {
@@ -301,7 +309,7 @@
         "inherits": [
             "build-dir",
             "build-benchmarks",
-            "ci-unix"
+            "ci-macos"
         ]
     },
     {

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class RppConan(ConanFile):
             self.requires("nanobench/4.3.11")
 
         if self.options.with_sfml:
-            self.requires("sfml/2.6.1", options={"audio": False})
+            self.requires("sfml/2.6.2", options={"audio": False})
 
         if self.options.with_grpc:
             self.requires("grpc/1.54.3", transitive_libs=True, transitive_headers=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to ensure the Python templating package (Jinja2) is installed early so dependency tooling can run reliably.
  * SFML dependency bumped from 2.6.1 to 2.6.2 when the SFML option is enabled.
  * Build configuration: added a hidden macOS preset that introduces a new compiler warning flag and updated macOS presets to inherit from it.
  * No other user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->