### PR TITLE
Update CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,7 +30,8 @@
         "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_CXX_STANDARD": "20",
         "CMAKE_CXX_STANDARD_REQUIRED": "ON",
-        "RPP_DEVELOPER_MODE": "ON"
+        "RPP_DEVELOPER_MODE": "ON".
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,7 +30,7 @@
         "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_CXX_STANDARD": "20",
         "CMAKE_CXX_STANDARD_REQUIRED": "ON",
-        "RPP_DEVELOPER_MODE": "ON".
+        "RPP_DEVELOPER_MODE": "ON",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI configure preset updated to specify a minimum CMake policy version for builds.
  - Developer mode flag left unchanged in the CI configure preset.
  - Changes affect build configuration in CI only and introduce no user-facing features or interface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->