### PR TITLE
add missing #include <new>

### DIFF
--- a/src/rpp/rpp/disposables/details/container.hpp
+++ b/src/rpp/rpp/disposables/details/container.hpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <new>
 
 namespace rpp::details::disposables
 {

--- a/src/rpp/rpp/disposables/details/container.hpp
+++ b/src/rpp/rpp/disposables/details/container.hpp
@@ -13,8 +13,8 @@
 #include <rpp/utils/exceptions.hpp>
 
 #include <algorithm>
-#include <vector>
 #include <new>
+#include <vector>
 
 namespace rpp::details::disposables
 {


### PR DESCRIPTION
Fix compilation error with clang 21 and c++23:

error: no member named 'launder' in namespace 'std'
  143 |             return std::launder(reinterpret_cast<const rpp::disposable_wrapper*>(&m_data[i * sizeof(rpp::disposable_wrapper)]));

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal improvements and maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->